### PR TITLE
Adding cancel and restart to threadpool timer

### DIFF
--- a/interfaces/devdoc/threadpool_requirements.md
+++ b/interfaces/devdoc/threadpool_requirements.md
@@ -9,7 +9,11 @@ A `threadpool` object receives an execution engine at creation time in order to 
 
 The `threadpool` interface supports:
  - Scheduling a single work item (`threadpool_schedule_work`)
- - Scheduling a timer function to execute at a regular interval (`threadpool_start_timer`/`threadpool_stop_timer`)
+ - Scheduling a timer function to execute at a regular interval
+   - `threadpool_start_timer`
+   - `threadpool_stop_timer`
+   - `threadpool_restart_timer`
+   - `threadpool_cancel_timer`
 
 The lifetime of the execution engine should supersede the lifetime of the `threadpool` object.
 
@@ -37,6 +41,10 @@ MOCKABLE_FUNCTION(, void, threadpool_close, THREADPOOL_HANDLE, threadpool);
 MOCKABLE_FUNCTION(, int, threadpool_schedule_work, THREADPOOL_HANDLE, threadpool, THREADPOOL_WORK_FUNCTION, work_function, void*, work_function_context);
 
 MOCKABLE_FUNCTION(, int, threadpool_start_timer, THREADPOOL_HANDLE, threadpool, uint32_t, start_delay_ms, uint32_t, timer_period_ms, THREADPOOL_WORK_FUNCTION, work_function, void*, work_function_context, TIMER_INSTANCE_HANDLE*, timer_handle);
+
+MOCKABLE_FUNCTION(, int, threadpool_restart_timer, TIMER_INSTANCE_HANDLE, timer, uint32_t, start_delay_ms, uint32_t, timer_period_ms);
+
+MOCKABLE_FUNCTION(, void, threadpool_cancel_timer, TIMER_INSTANCE_HANDLE, timer);
 
 MOCKABLE_FUNCTION(, void, threadpool_stop_timer, TIMER_INSTANCE_HANDLE, timer);
 ```
@@ -158,6 +166,36 @@ MOCKABLE_FUNCTION(, int, threadpool_start_timer, THREADPOOL_HANDLE, threadpool, 
 **SRS_THREADPOOL_42_010: [** `threadpool_start_timer` shall return the allocated handle in `timer_handle`. **]**
 
 **SRS_THREADPOOL_42_011: [** `threadpool_start_timer` shall succeed and return 0. **]**
+
+### threadpool_restart_timer
+
+```c
+MOCKABLE_FUNCTION(, int, threadpool_restart_timer, TIMER_INSTANCE_HANDLE, timer, uint32_t, start_delay_ms, uint32_t, timer_period_ms);
+```
+
+`threadpool_restart_timer` changes the delay and period of an existing timer.
+
+**SRS_THREADPOOL_42_015: [** If `timer` is `NULL`, `threadpool_restart_timer` shall fail and return a non-zero value. **]**
+
+**SRS_THREADPOOL_42_016: [** `threadpool_restart_timer` shall stop execution of the existing timer and wait for any current executions to complete. **]**
+
+**SRS_THREADPOOL_42_017: [** If `timer_period_ms` is 0 then `threadpool_restart_timer` shall queue for execution the function `work_function` to be executed once after `start_delay_ms` pass `context` to it when it executes. **]**
+
+**SRS_THREADPOOL_42_018: [** Otherwise `threadpool_restart_timer` shall queue for execution the function `work_function` to be executed after `start_delay_ms` and every `timer_period_ms` thereafter and pass `context` to it when it executes. **]**
+
+**SRS_THREADPOOL_42_019: [** `threadpool_restart_timer` shall succeed and return 0. **]**
+
+### threadpool_cancel_timer
+
+```c
+MOCKABLE_FUNCTION(, void, threadpool_cancel_timer, TIMER_INSTANCE_HANDLE, timer);
+```
+
+`threadpool_cancel_timer` stops the timer and waits for any pending callbacks. Afterward, the timer may be resumed with a new time by calling `threadpool_restart_timer` or cleaned up by calling `threadpool_stop_timer`.
+
+**SRS_THREADPOOL_42_020: [** If `timer` is `NULL`, `threadpool_cancel_timer` shall fail and return. **]**
+
+**SRS_THREADPOOL_42_021: [** `threadpool_cancel_timer` shall stop further execution of the timer and wait for any current executions to complete. **]**
 
 ### threadpool_stop_timer
 

--- a/interfaces/devdoc/threadpool_requirements.md
+++ b/interfaces/devdoc/threadpool_requirements.md
@@ -10,10 +10,10 @@ A `threadpool` object receives an execution engine at creation time in order to 
 The `threadpool` interface supports:
  - Scheduling a single work item (`threadpool_schedule_work`)
  - Scheduling a timer function to execute at a regular interval
-   - `threadpool_start_timer`
-   - `threadpool_stop_timer`
-   - `threadpool_restart_timer`
-   - `threadpool_cancel_timer`
+   - `threadpool_timer_start`
+   - `threadpool_timer_destroy`
+   - `threadpool_timer_restart`
+   - `threadpool_timer_cancel`
 
 The lifetime of the execution engine should supersede the lifetime of the `threadpool` object.
 
@@ -40,13 +40,13 @@ MOCKABLE_FUNCTION(, void, threadpool_close, THREADPOOL_HANDLE, threadpool);
 
 MOCKABLE_FUNCTION(, int, threadpool_schedule_work, THREADPOOL_HANDLE, threadpool, THREADPOOL_WORK_FUNCTION, work_function, void*, work_function_context);
 
-MOCKABLE_FUNCTION(, int, threadpool_start_timer, THREADPOOL_HANDLE, threadpool, uint32_t, start_delay_ms, uint32_t, timer_period_ms, THREADPOOL_WORK_FUNCTION, work_function, void*, work_function_context, TIMER_INSTANCE_HANDLE*, timer_handle);
+MOCKABLE_FUNCTION(, int, threadpool_timer_start, THREADPOOL_HANDLE, threadpool, uint32_t, start_delay_ms, uint32_t, timer_period_ms, THREADPOOL_WORK_FUNCTION, work_function, void*, work_function_context, TIMER_INSTANCE_HANDLE*, timer_handle);
 
-MOCKABLE_FUNCTION(, int, threadpool_restart_timer, TIMER_INSTANCE_HANDLE, timer, uint32_t, start_delay_ms, uint32_t, timer_period_ms);
+MOCKABLE_FUNCTION(, int, threadpool_timer_restart, TIMER_INSTANCE_HANDLE, timer, uint32_t, start_delay_ms, uint32_t, timer_period_ms);
 
-MOCKABLE_FUNCTION(, void, threadpool_cancel_timer, TIMER_INSTANCE_HANDLE, timer);
+MOCKABLE_FUNCTION(, void, threadpool_timer_cancel, TIMER_INSTANCE_HANDLE, timer);
 
-MOCKABLE_FUNCTION(, void, threadpool_stop_timer, TIMER_INSTANCE_HANDLE, timer);
+MOCKABLE_FUNCTION(, void, threadpool_timer_destroy, TIMER_INSTANCE_HANDLE, timer);
 ```
 
 ### threadpool_create
@@ -139,13 +139,13 @@ Note: There are no guarantees regarding the order of execution for the `work_fun
 
 **SRS_THREADPOOL_01_024: [** If any error occurs, `threadpool_schedule_work` shall fail and return a non-zero value. **]**
 
-### threadpool_start_timer
+### threadpool_timer_start
 
 ```c
-MOCKABLE_FUNCTION(, int, threadpool_start_timer, THREADPOOL_HANDLE, threadpool, uint32_t, start_delay_ms, uint32_t, timer_period_ms, THREADPOOL_WORK_FUNCTION, work_function, void*, work_function_context, TIMER_INSTANCE_HANDLE*, timer_handle);
+MOCKABLE_FUNCTION(, int, threadpool_timer_start, THREADPOOL_HANDLE, threadpool, uint32_t, start_delay_ms, uint32_t, timer_period_ms, THREADPOOL_WORK_FUNCTION, work_function, void*, work_function_context, TIMER_INSTANCE_HANDLE*, timer_handle);
 ```
 
-`threadpool_start_timer` starts a threadpool timer which runs after `start_delay_ms` milliseconds and then runs again every `timer_period_ms` milliseconds until `threadpool_stop_timer` is called. The `timer_handle` must be stopped before closing/destroying the threadpool.
+`threadpool_timer_start` starts a threadpool timer which runs after `start_delay_ms` milliseconds and then runs again every `timer_period_ms` milliseconds until `threadpool_timer_destroy` is called. The `timer_handle` must be stopped before closing/destroying the threadpool.
 
 **SRS_THREADPOOL_42_001: [** If `threadpool` is `NULL`, `threadpool_schedule_work` shall fail and return a non-zero value. **]**
 
@@ -155,58 +155,58 @@ MOCKABLE_FUNCTION(, int, threadpool_start_timer, THREADPOOL_HANDLE, threadpool, 
 
 **SRS_THREADPOOL_42_004: [** `work_function_context` shall be allowed to be `NULL`. **]**
 
-**SRS_THREADPOOL_42_005: [** `threadpool_start_timer` shall allocate a context for the timer being started and store `work_function` and `work_function_context` in it. **]**
+**SRS_THREADPOOL_42_005: [** `threadpool_timer_start` shall allocate a context for the timer being started and store `work_function` and `work_function_context` in it. **]**
 
-**SRS_THREADPOOL_42_007: [** If `timer_period_ms` is 0 then `threadpool_start_timer` shall queue for execution the function `work_function` to be executed once after `start_delay_ms` pass `context` to it when it executes. **]**
+**SRS_THREADPOOL_42_007: [** If `timer_period_ms` is 0 then `threadpool_timer_start` shall queue for execution the function `work_function` to be executed once after `start_delay_ms` pass `context` to it when it executes. **]**
 
-**SRS_THREADPOOL_42_008: [** Otherwise `threadpool_start_timer` shall queue for execution the function `work_function` to be executed after `start_delay_ms` and every `timer_period_ms` thereafter and pass `context` to it when it executes. **]**
+**SRS_THREADPOOL_42_008: [** Otherwise `threadpool_timer_start` shall queue for execution the function `work_function` to be executed after `start_delay_ms` and every `timer_period_ms` thereafter and pass `context` to it when it executes. **]**
 
-**SRS_THREADPOOL_42_009: [** If any error occurs, `threadpool_start_timer` shall fail and return a non-zero value. **]**
+**SRS_THREADPOOL_42_009: [** If any error occurs, `threadpool_timer_start` shall fail and return a non-zero value. **]**
 
-**SRS_THREADPOOL_42_010: [** `threadpool_start_timer` shall return the allocated handle in `timer_handle`. **]**
+**SRS_THREADPOOL_42_010: [** `threadpool_timer_start` shall return the allocated handle in `timer_handle`. **]**
 
-**SRS_THREADPOOL_42_011: [** `threadpool_start_timer` shall succeed and return 0. **]**
+**SRS_THREADPOOL_42_011: [** `threadpool_timer_start` shall succeed and return 0. **]**
 
-### threadpool_restart_timer
-
-```c
-MOCKABLE_FUNCTION(, int, threadpool_restart_timer, TIMER_INSTANCE_HANDLE, timer, uint32_t, start_delay_ms, uint32_t, timer_period_ms);
-```
-
-`threadpool_restart_timer` changes the delay and period of an existing timer.
-
-**SRS_THREADPOOL_42_015: [** If `timer` is `NULL`, `threadpool_restart_timer` shall fail and return a non-zero value. **]**
-
-**SRS_THREADPOOL_42_016: [** `threadpool_restart_timer` shall stop execution of the existing timer and wait for any current executions to complete. **]**
-
-**SRS_THREADPOOL_42_017: [** If `timer_period_ms` is 0 then `threadpool_restart_timer` shall queue for execution the function `work_function` to be executed once after `start_delay_ms` pass `context` to it when it executes. **]**
-
-**SRS_THREADPOOL_42_018: [** Otherwise `threadpool_restart_timer` shall queue for execution the function `work_function` to be executed after `start_delay_ms` and every `timer_period_ms` thereafter and pass `context` to it when it executes. **]**
-
-**SRS_THREADPOOL_42_019: [** `threadpool_restart_timer` shall succeed and return 0. **]**
-
-### threadpool_cancel_timer
+### threadpool_timer_restart
 
 ```c
-MOCKABLE_FUNCTION(, void, threadpool_cancel_timer, TIMER_INSTANCE_HANDLE, timer);
+MOCKABLE_FUNCTION(, int, threadpool_timer_restart, TIMER_INSTANCE_HANDLE, timer, uint32_t, start_delay_ms, uint32_t, timer_period_ms);
 ```
 
-`threadpool_cancel_timer` stops the timer and waits for any pending callbacks. Afterward, the timer may be resumed with a new time by calling `threadpool_restart_timer` or cleaned up by calling `threadpool_stop_timer`.
+`threadpool_timer_restart` changes the delay and period of an existing timer.
 
-**SRS_THREADPOOL_42_020: [** If `timer` is `NULL`, `threadpool_cancel_timer` shall fail and return. **]**
+**SRS_THREADPOOL_42_015: [** If `timer` is `NULL`, `threadpool_timer_restart` shall fail and return a non-zero value. **]**
 
-**SRS_THREADPOOL_42_021: [** `threadpool_cancel_timer` shall stop further execution of the timer and wait for any current executions to complete. **]**
+**SRS_THREADPOOL_42_016: [** `threadpool_timer_restart` shall stop execution of the existing timer and wait for any current executions to complete. **]**
 
-### threadpool_stop_timer
+**SRS_THREADPOOL_42_017: [** If `timer_period_ms` is 0 then `threadpool_timer_restart` shall queue for execution the function `work_function` to be executed once after `start_delay_ms` pass `context` to it when it executes. **]**
+
+**SRS_THREADPOOL_42_018: [** Otherwise `threadpool_timer_restart` shall queue for execution the function `work_function` to be executed after `start_delay_ms` and every `timer_period_ms` thereafter and pass `context` to it when it executes. **]**
+
+**SRS_THREADPOOL_42_019: [** `threadpool_timer_restart` shall succeed and return 0. **]**
+
+### threadpool_timer_cancel
 
 ```c
-MOCKABLE_FUNCTION(, void, threadpool_stop_timer, TIMER_INSTANCE_HANDLE, timer);
+MOCKABLE_FUNCTION(, void, threadpool_timer_cancel, TIMER_INSTANCE_HANDLE, timer);
 ```
 
-`threadpool_stop_timer` stops the timer started by `threadpool_start_timer` and cleans up its resources.
+`threadpool_timer_cancel` stops the timer and waits for any pending callbacks. Afterward, the timer may be resumed with a new time by calling `threadpool_timer_restart` or cleaned up by calling `threadpool_timer_destroy`.
 
-**SRS_THREADPOOL_42_012: [** If `timer` is `NULL`, `threadpool_stop_timer` shall fail and return. **]**
+**SRS_THREADPOOL_42_020: [** If `timer` is `NULL`, `threadpool_timer_cancel` shall fail and return. **]**
 
-**SRS_THREADPOOL_42_013: [** `threadpool_stop_timer` shall stop further execution of the timer and wait for any current executions to complete. **]**
+**SRS_THREADPOOL_42_021: [** `threadpool_timer_cancel` shall stop further execution of the timer and wait for any current executions to complete. **]**
 
-**SRS_THREADPOOL_42_014: [** `threadpool_stop_timer` shall free all resources in `timer`. **]**
+### threadpool_timer_destroy
+
+```c
+MOCKABLE_FUNCTION(, void, threadpool_timer_destroy, TIMER_INSTANCE_HANDLE, timer);
+```
+
+`threadpool_timer_destroy` stops the timer started by `threadpool_timer_start` and cleans up its resources.
+
+**SRS_THREADPOOL_42_012: [** If `timer` is `NULL`, `threadpool_timer_destroy` shall fail and return. **]**
+
+**SRS_THREADPOOL_42_013: [** `threadpool_timer_destroy` shall stop further execution of the timer and wait for any current executions to complete. **]**
+
+**SRS_THREADPOOL_42_014: [** `threadpool_timer_destroy` shall free all resources in `timer`. **]**

--- a/interfaces/inc/c_pal/threadpool.h
+++ b/interfaces/inc/c_pal/threadpool.h
@@ -37,13 +37,13 @@ MOCKABLE_FUNCTION(, void, threadpool_close, THREADPOOL_HANDLE, threadpool);
 
 MOCKABLE_FUNCTION(, int, threadpool_schedule_work, THREADPOOL_HANDLE, threadpool, THREADPOOL_WORK_FUNCTION, work_function, void*, work_function_context);
 
-MOCKABLE_FUNCTION(, int, threadpool_start_timer, THREADPOOL_HANDLE, threadpool, uint32_t, start_delay_ms, uint32_t, timer_period_ms, THREADPOOL_WORK_FUNCTION, work_function, void*, work_function_context, TIMER_INSTANCE_HANDLE*, timer_handle);
+MOCKABLE_FUNCTION(, int, threadpool_timer_start, THREADPOOL_HANDLE, threadpool, uint32_t, start_delay_ms, uint32_t, timer_period_ms, THREADPOOL_WORK_FUNCTION, work_function, void*, work_function_context, TIMER_INSTANCE_HANDLE*, timer_handle);
 
-MOCKABLE_FUNCTION(, int, threadpool_restart_timer, TIMER_INSTANCE_HANDLE, timer, uint32_t, start_delay_ms, uint32_t, timer_period_ms);
+MOCKABLE_FUNCTION(, int, threadpool_timer_restart, TIMER_INSTANCE_HANDLE, timer, uint32_t, start_delay_ms, uint32_t, timer_period_ms);
 
-MOCKABLE_FUNCTION(, void, threadpool_cancel_timer, TIMER_INSTANCE_HANDLE, timer);
+MOCKABLE_FUNCTION(, void, threadpool_timer_cancel, TIMER_INSTANCE_HANDLE, timer);
 
-MOCKABLE_FUNCTION(, void, threadpool_stop_timer, TIMER_INSTANCE_HANDLE, timer);
+MOCKABLE_FUNCTION(, void, threadpool_timer_destroy, TIMER_INSTANCE_HANDLE, timer);
 
 #ifdef __cplusplus
 }

--- a/interfaces/inc/c_pal/threadpool.h
+++ b/interfaces/inc/c_pal/threadpool.h
@@ -39,6 +39,10 @@ MOCKABLE_FUNCTION(, int, threadpool_schedule_work, THREADPOOL_HANDLE, threadpool
 
 MOCKABLE_FUNCTION(, int, threadpool_start_timer, THREADPOOL_HANDLE, threadpool, uint32_t, start_delay_ms, uint32_t, timer_period_ms, THREADPOOL_WORK_FUNCTION, work_function, void*, work_function_context, TIMER_INSTANCE_HANDLE*, timer_handle);
 
+MOCKABLE_FUNCTION(, int, threadpool_restart_timer, TIMER_INSTANCE_HANDLE, timer, uint32_t, start_delay_ms, uint32_t, timer_period_ms);
+
+MOCKABLE_FUNCTION(, void, threadpool_cancel_timer, TIMER_INSTANCE_HANDLE, timer);
+
 MOCKABLE_FUNCTION(, void, threadpool_stop_timer, TIMER_INSTANCE_HANDLE, timer);
 
 #ifdef __cplusplus

--- a/win32/devdoc/threadpool_win32.md
+++ b/win32/devdoc/threadpool_win32.md
@@ -34,6 +34,10 @@ MOCKABLE_FUNCTION(, int, threadpool_schedule_work, THREADPOOL_HANDLE, threadpool
 
 MOCKABLE_FUNCTION(, int, threadpool_start_timer, THREADPOOL_HANDLE, threadpool, uint32_t, start_delay_ms, uint32_t, timer_period_ms, THREADPOOL_WORK_FUNCTION, work_function, void*, work_function_context, TIMER_INSTANCE_HANDLE*, timer_handle);
 
+MOCKABLE_FUNCTION(, int, threadpool_restart_timer, TIMER_INSTANCE_HANDLE, timer, uint32_t, start_delay_ms, uint32_t, timer_period_ms);
+
+MOCKABLE_FUNCTION(, void, threadpool_cancel_timer, TIMER_INSTANCE_HANDLE, timer);
+
 MOCKABLE_FUNCTION(, void, threadpool_stop_timer, TIMER_INSTANCE_HANDLE, timer);
 ```
 
@@ -190,6 +194,34 @@ MOCKABLE_FUNCTION(, int, threadpool_start_timer, THREADPOOL_HANDLE, threadpool, 
 **SRS_THREADPOOL_WIN32_42_009: [** `threadpool_start_timer` shall return the allocated handle in `timer_handle`. **]**
 
 **SRS_THREADPOOL_WIN32_42_010: [** `threadpool_start_timer` shall succeed and return 0. **]**
+
+### threadpool_restart_timer
+
+```c
+MOCKABLE_FUNCTION(, int, threadpool_restart_timer, TIMER_INSTANCE_HANDLE, timer, uint32_t, start_delay_ms, uint32_t, timer_period_ms);
+```
+
+`threadpool_restart_timer` changes the delay and period of an existing timer.
+
+**SRS_THREADPOOL_WIN32_42_019: [** If `timer` is `NULL`, `threadpool_restart_timer` shall fail and return a non-zero value. **]**
+
+**SRS_THREADPOOL_WIN32_42_022: [** `threadpool_restart_timer` shall call `SetThreadpoolTimer`, passing negative `start_delay_ms` as `pftDueTime`, `timer_period_ms` as `msPeriod`, and 0 as `msWindowLength`. **]**
+
+**SRS_THREADPOOL_WIN32_42_023: [** `threadpool_restart_timer` shall succeed and return 0. **]**
+
+### threadpool_cancel_timer
+
+```c
+MOCKABLE_FUNCTION(, void, threadpool_cancel_timer, TIMER_INSTANCE_HANDLE, timer);
+```
+
+`threadpool_cancel_timer` stops the timer and waits for any pending callbacks. Afterward, the timer may be resumed with a new time by calling `threadpool_restart_timer` or cleaned up by calling `threadpool_stop_timer`.
+
+**SRS_THREADPOOL_WIN32_42_024: [** If `timer` is `NULL`, `threadpool_cancel_timer` shall fail and return. **]**
+
+**SRS_THREADPOOL_WIN32_42_025: [** `threadpool_cancel_timer` shall call `SetThreadpoolTimer` with `NULL` for `pftDueTime` and 0 for `msPeriod` and `msWindowLength` to cancel ongoing timers. **]**
+
+**SRS_THREADPOOL_WIN32_42_026: [** `threadpool_cancel_timer` shall call `WaitForThreadpoolTimerCallbacks`. **]**
 
 ### threadpool_stop_timer
 

--- a/win32/src/threadpool_win32.c
+++ b/win32/src/threadpool_win32.c
@@ -380,7 +380,7 @@ static void threadpool_internal_cancel_timer_and_wait(PTP_TIMER tp_timer)
     WaitForThreadpoolTimerCallbacks(tp_timer, TRUE);
 }
 
-int threadpool_start_timer(THREADPOOL_HANDLE threadpool, uint32_t start_delay_ms, uint32_t timer_period_ms, THREADPOOL_WORK_FUNCTION work_function, void* work_function_context, TIMER_INSTANCE_HANDLE* timer_handle)
+int threadpool_timer_start(THREADPOOL_HANDLE threadpool, uint32_t start_delay_ms, uint32_t timer_period_ms, THREADPOOL_WORK_FUNCTION work_function, void* work_function_context, TIMER_INSTANCE_HANDLE* timer_handle)
 {
     int result;
 
@@ -410,23 +410,23 @@ int threadpool_start_timer(THREADPOOL_HANDLE threadpool, uint32_t start_delay_ms
         }
         else
         {
-            /* Codes_SRS_THREADPOOL_WIN32_42_005: [ threadpool_start_timer shall allocate a context for the timer being started and store work_function and work_function_context in it. ]*/
+            /* Codes_SRS_THREADPOOL_WIN32_42_005: [ threadpool_timer_start shall allocate a context for the timer being started and store work_function and work_function_context in it. ]*/
             TIMER_INSTANCE_HANDLE timer_temp = malloc(sizeof(TIMER_INSTANCE));
 
             if (timer_temp == NULL)
             {
-                /* Codes_SRS_THREADPOOL_WIN32_42_008: [ If any error occurs, threadpool_start_timer shall fail and return a non-zero value. ]*/
+                /* Codes_SRS_THREADPOOL_WIN32_42_008: [ If any error occurs, threadpool_timer_start shall fail and return a non-zero value. ]*/
                 LogError("malloc(%zu) failed for TIMER_INSTANCE_HANDLE", sizeof(TIMER_INSTANCE));
                 result = MU_FAILURE;
             }
             else
             {
-                /* Codes_SRS_THREADPOOL_WIN32_42_006: [ threadpool_start_timer shall call CreateThreadpoolTimer to schedule execution the callback while passing to it the on_timer_callback function and the newly created context. ]*/
+                /* Codes_SRS_THREADPOOL_WIN32_42_006: [ threadpool_timer_start shall call CreateThreadpoolTimer to schedule execution the callback while passing to it the on_timer_callback function and the newly created context. ]*/
                 PTP_TIMER tp_timer = CreateThreadpoolTimer(on_timer_callback, timer_temp, &threadpool->tp_environment);
 
                 if (tp_timer == NULL)
                 {
-                    /* Codes_SRS_THREADPOOL_WIN32_42_008: [ If any error occurs, threadpool_start_timer shall fail and return a non-zero value. ]*/
+                    /* Codes_SRS_THREADPOOL_WIN32_42_008: [ If any error occurs, threadpool_timer_start shall fail and return a non-zero value. ]*/
                     LogError("CreateThreadpoolTimer failed");
                     result = MU_FAILURE;
                 }
@@ -436,14 +436,14 @@ int threadpool_start_timer(THREADPOOL_HANDLE threadpool, uint32_t start_delay_ms
                     timer_temp->work_function = work_function;
                     timer_temp->work_function_context = work_function_context;
 
-                    /* Codes_SRS_THREADPOOL_WIN32_42_007: [ threadpool_start_timer shall call SetThreadpoolTimer, passing negative start_delay_ms as pftDueTime, timer_period_ms as msPeriod, and 0 as msWindowLength. ]*/
+                    /* Codes_SRS_THREADPOOL_WIN32_42_007: [ threadpool_timer_start shall call SetThreadpoolTimer, passing negative start_delay_ms as pftDueTime, timer_period_ms as msPeriod, and 0 as msWindowLength. ]*/
                     threadpool_internal_set_timer(tp_timer, start_delay_ms, timer_period_ms);
 
-                    /* Codes_SRS_THREADPOOL_WIN32_42_009: [ threadpool_start_timer shall return the allocated handle in timer_handle. ]*/
+                    /* Codes_SRS_THREADPOOL_WIN32_42_009: [ threadpool_timer_start shall return the allocated handle in timer_handle. ]*/
                     *timer_handle = timer_temp;
                     timer_temp = NULL;
 
-                    /* Codes_SRS_THREADPOOL_WIN32_42_010: [ threadpool_start_timer shall succeed and return 0. ]*/
+                    /* Codes_SRS_THREADPOOL_WIN32_42_010: [ threadpool_timer_start shall succeed and return 0. ]*/
                     result = 0;
                 }
 
@@ -461,12 +461,12 @@ int threadpool_start_timer(THREADPOOL_HANDLE threadpool, uint32_t start_delay_ms
     return result;
 }
 
-int threadpool_restart_timer(TIMER_INSTANCE_HANDLE timer, uint32_t start_delay_ms, uint32_t timer_period_ms)
+int threadpool_timer_restart(TIMER_INSTANCE_HANDLE timer, uint32_t start_delay_ms, uint32_t timer_period_ms)
 {
     int result;
 
     if (
-        /* Codes_SRS_THREADPOOL_WIN32_42_019: [ If timer is NULL, threadpool_restart_timer shall fail and return a non-zero value. ]*/
+        /* Codes_SRS_THREADPOOL_WIN32_42_019: [ If timer is NULL, threadpool_timer_restart shall fail and return a non-zero value. ]*/
         timer == NULL
         )
     {
@@ -476,48 +476,48 @@ int threadpool_restart_timer(TIMER_INSTANCE_HANDLE timer, uint32_t start_delay_m
     }
     else
     {
-        /* Codes_SRS_THREADPOOL_WIN32_42_022: [ threadpool_restart_timer shall call SetThreadpoolTimer, passing negative start_delay_ms as pftDueTime, timer_period_ms as msPeriod, and 0 as msWindowLength. ]*/
+        /* Codes_SRS_THREADPOOL_WIN32_42_022: [ threadpool_timer_restart shall call SetThreadpoolTimer, passing negative start_delay_ms as pftDueTime, timer_period_ms as msPeriod, and 0 as msWindowLength. ]*/
         threadpool_internal_set_timer(timer->timer, start_delay_ms, timer_period_ms);
 
-        /* Codes_SRS_THREADPOOL_WIN32_42_023: [ threadpool_restart_timer shall succeed and return 0. ]*/
+        /* Codes_SRS_THREADPOOL_WIN32_42_023: [ threadpool_timer_restart shall succeed and return 0. ]*/
         result = 0;
     }
 
     return result;
 }
 
-void threadpool_cancel_timer(TIMER_INSTANCE_HANDLE timer)
+void threadpool_timer_cancel(TIMER_INSTANCE_HANDLE timer)
 {
     if (timer == NULL)
     {
-        /* Codes_SRS_THREADPOOL_WIN32_42_024: [ If timer is NULL, threadpool_cancel_timer shall fail and return. ]*/
+        /* Codes_SRS_THREADPOOL_WIN32_42_024: [ If timer is NULL, threadpool_timer_cancel shall fail and return. ]*/
         LogError("Invalid args: TIMER_INSTANCE_HANDLE timer = %p", timer);
     }
     else
     {
-        /* Codes_SRS_THREADPOOL_WIN32_42_025: [ threadpool_cancel_timer shall call SetThreadpoolTimer with NULL for pftDueTime and 0 for msPeriod and msWindowLength to cancel ongoing timers. ]*/
-        /* Codes_SRS_THREADPOOL_WIN32_42_026: [ threadpool_cancel_timer shall call WaitForThreadpoolTimerCallbacks. ]*/
+        /* Codes_SRS_THREADPOOL_WIN32_42_025: [ threadpool_timer_cancel shall call SetThreadpoolTimer with NULL for pftDueTime and 0 for msPeriod and msWindowLength to cancel ongoing timers. ]*/
+        /* Codes_SRS_THREADPOOL_WIN32_42_026: [ threadpool_timer_cancel shall call WaitForThreadpoolTimerCallbacks. ]*/
         threadpool_internal_cancel_timer_and_wait(timer->timer);
     }
 }
 
-void threadpool_stop_timer(TIMER_INSTANCE_HANDLE timer)
+void threadpool_timer_destroy(TIMER_INSTANCE_HANDLE timer)
 {
     if (timer == NULL)
     {
-        /* Codes_SRS_THREADPOOL_WIN32_42_011: [ If timer is NULL, threadpool_stop_timer shall fail and return. ]*/
+        /* Codes_SRS_THREADPOOL_WIN32_42_011: [ If timer is NULL, threadpool_timer_destroy shall fail and return. ]*/
         LogError("Invalid args: TIMER_INSTANCE_HANDLE timer = %p", timer);
     }
     else
     {
-        /* Codes_SRS_THREADPOOL_WIN32_42_012: [ threadpool_stop_timer shall call SetThreadpoolTimer with NULL for pftDueTime and 0 for msPeriod and msWindowLength to cancel ongoing timers. ]*/
-        /* Codes_SRS_THREADPOOL_WIN32_42_013: [ threadpool_stop_timer shall call WaitForThreadpoolTimerCallbacks. ]*/
+        /* Codes_SRS_THREADPOOL_WIN32_42_012: [ threadpool_timer_destroy shall call SetThreadpoolTimer with NULL for pftDueTime and 0 for msPeriod and msWindowLength to cancel ongoing timers. ]*/
+        /* Codes_SRS_THREADPOOL_WIN32_42_013: [ threadpool_timer_destroy shall call WaitForThreadpoolTimerCallbacks. ]*/
         threadpool_internal_cancel_timer_and_wait(timer->timer);
 
-        /* Codes_SRS_THREADPOOL_WIN32_42_014: [ threadpool_stop_timer shall call CloseThreadpoolTimer. ]*/
+        /* Codes_SRS_THREADPOOL_WIN32_42_014: [ threadpool_timer_destroy shall call CloseThreadpoolTimer. ]*/
         CloseThreadpoolTimer(timer->timer);
 
-        /* Codes_SRS_THREADPOOL_WIN32_42_015: [ threadpool_stop_timer shall free all resources in timer. ]*/
+        /* Codes_SRS_THREADPOOL_WIN32_42_015: [ threadpool_timer_destroy shall free all resources in timer. ]*/
         free(timer);
     }
 }

--- a/win32/tests/threadpool_win32_ut/threadpool_win32_ut.c
+++ b/win32/tests/threadpool_win32_ut/threadpool_win32_ut.c
@@ -264,7 +264,7 @@ static void test_create_threadpool_and_start_timer(uint32_t start_delay_ms, uint
         .CaptureReturn(ptp_timer);
     STRICT_EXPECTED_CALL(mocked_SetThreadpoolTimer(IGNORED_ARG, IGNORED_ARG, 2000, 0));
 
-    ASSERT_ARE_EQUAL(int, 0, threadpool_start_timer(*threadpool, start_delay_ms, timer_period_ms, test_work_function, work_function_context, timer_instance));
+    ASSERT_ARE_EQUAL(int, 0, threadpool_timer_start(*threadpool, start_delay_ms, timer_period_ms, test_work_function, work_function_context, timer_instance));
     umock_c_reset_all_calls();
 }
 
@@ -1003,16 +1003,16 @@ TEST_FUNCTION(on_work_callback_triggers_the_user_work_function_with_NULL_work_fu
     threadpool_destroy(threadpool);
 }
 
-/* threadpool_start_timer */
+/* threadpool_timer_start */
 
 /* Tests_SRS_THREADPOOL_WIN32_42_001: [ If threadpool is NULL, threadpool_schedule_work shall fail and return a non-zero value. ]*/
-TEST_FUNCTION(threadpool_start_timer_with_NULL_threadpool_fails)
+TEST_FUNCTION(threadpool_timer_start_with_NULL_threadpool_fails)
 {
     // arrange
     TIMER_INSTANCE_HANDLE timer_instance;
 
     // act
-    int result = threadpool_start_timer(NULL, 42, 2000, test_work_function, (void*)0x4243, &timer_instance);
+    int result = threadpool_timer_start(NULL, 42, 2000, test_work_function, (void*)0x4243, &timer_instance);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1020,7 +1020,7 @@ TEST_FUNCTION(threadpool_start_timer_with_NULL_threadpool_fails)
 }
 
 /* Tests_SRS_THREADPOOL_WIN32_42_002: [ If work_function is NULL, threadpool_schedule_work shall fail and return a non-zero value. ]*/
-TEST_FUNCTION(threadpool_start_timer_with_NULL_work_function_fails)
+TEST_FUNCTION(threadpool_timer_start_with_NULL_work_function_fails)
 {
     // arrange
     PTP_CALLBACK_ENVIRON cbe;
@@ -1029,7 +1029,7 @@ TEST_FUNCTION(threadpool_start_timer_with_NULL_work_function_fails)
     TIMER_INSTANCE_HANDLE timer_instance;
 
     // act
-    int result = threadpool_start_timer(threadpool, 42, 2000, NULL, (void*)0x4243, &timer_instance);
+    int result = threadpool_timer_start(threadpool, 42, 2000, NULL, (void*)0x4243, &timer_instance);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1040,14 +1040,14 @@ TEST_FUNCTION(threadpool_start_timer_with_NULL_work_function_fails)
 }
 
 /* Tests_SRS_THREADPOOL_WIN32_42_003: [ If timer_handle is NULL, threadpool_schedule_work shall fail and return a non-zero value. ]*/
-TEST_FUNCTION(threadpool_start_timer_with_NULL_timer_handle_fails)
+TEST_FUNCTION(threadpool_timer_start_with_NULL_timer_handle_fails)
 {
     // arrange
     PTP_CALLBACK_ENVIRON cbe;
     THREADPOOL_HANDLE threadpool = test_create_and_open_threadpool(&cbe);
 
     // act
-    int result = threadpool_start_timer(threadpool, 42, 2000, test_work_function, (void*)0x4243, NULL);
+    int result = threadpool_timer_start(threadpool, 42, 2000, test_work_function, (void*)0x4243, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1057,12 +1057,12 @@ TEST_FUNCTION(threadpool_start_timer_with_NULL_timer_handle_fails)
     threadpool_destroy(threadpool);
 }
 
-/* Tests_SRS_THREADPOOL_WIN32_42_005: [ threadpool_start_timer shall allocate a context for the timer being started and store work_function and work_function_context in it. ]*/
-/* Tests_SRS_THREADPOOL_WIN32_42_006: [ threadpool_start_timer shall call CreateThreadpoolTimer to schedule execution the callback while passing to it the on_timer_callback function and the newly created context. ]*/
-/* Tests_SRS_THREADPOOL_WIN32_42_007: [ threadpool_start_timer shall call SetThreadpoolTimer, passing negative start_delay_ms as pftDueTime, timer_period_ms as msPeriod, and 0 as msWindowLength. ]*/
-/* Tests_SRS_THREADPOOL_WIN32_42_009: [ threadpool_start_timer shall return the allocated handle in timer_handle. ]*/
-/* Tests_SRS_THREADPOOL_WIN32_42_010: [ threadpool_start_timer shall succeed and return 0. ]*/
-TEST_FUNCTION(threadpool_start_timer_succeeds)
+/* Tests_SRS_THREADPOOL_WIN32_42_005: [ threadpool_timer_start shall allocate a context for the timer being started and store work_function and work_function_context in it. ]*/
+/* Tests_SRS_THREADPOOL_WIN32_42_006: [ threadpool_timer_start shall call CreateThreadpoolTimer to schedule execution the callback while passing to it the on_timer_callback function and the newly created context. ]*/
+/* Tests_SRS_THREADPOOL_WIN32_42_007: [ threadpool_timer_start shall call SetThreadpoolTimer, passing negative start_delay_ms as pftDueTime, timer_period_ms as msPeriod, and 0 as msWindowLength. ]*/
+/* Tests_SRS_THREADPOOL_WIN32_42_009: [ threadpool_timer_start shall return the allocated handle in timer_handle. ]*/
+/* Tests_SRS_THREADPOOL_WIN32_42_010: [ threadpool_timer_start shall succeed and return 0. ]*/
+TEST_FUNCTION(threadpool_timer_start_succeeds)
 {
     // arrange
     PTP_CALLBACK_ENVIRON cbe;
@@ -1089,7 +1089,7 @@ TEST_FUNCTION(threadpool_start_timer_succeeds)
         .ValidateArgumentValue_pti(&ptp_timer);
 
     // act
-    int result = threadpool_start_timer(threadpool, 42, 2000, test_work_function, (void*)0x4243, &timer_instance);
+    int result = threadpool_timer_start(threadpool, 42, 2000, test_work_function, (void*)0x4243, &timer_instance);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1097,12 +1097,12 @@ TEST_FUNCTION(threadpool_start_timer_succeeds)
     ASSERT_IS_NOT_NULL(timer_instance);
 
     // cleanup
-    threadpool_stop_timer(timer_instance);
+    threadpool_timer_destroy(timer_instance);
     threadpool_destroy(threadpool);
 }
 
 /* Tests_SRS_THREADPOOL_WIN32_42_004: [ work_function_context shall be allowed to be NULL. ]*/
-TEST_FUNCTION(threadpool_start_timer_with_NULL_work_function_context_succeeds)
+TEST_FUNCTION(threadpool_timer_start_with_NULL_work_function_context_succeeds)
 {
     // arrange
     PTP_CALLBACK_ENVIRON cbe;
@@ -1129,7 +1129,7 @@ TEST_FUNCTION(threadpool_start_timer_with_NULL_work_function_context_succeeds)
         .ValidateArgumentValue_pti(&ptp_timer);
 
     // act
-    int result = threadpool_start_timer(threadpool, 42, 2000, test_work_function, NULL, &timer_instance);
+    int result = threadpool_timer_start(threadpool, 42, 2000, test_work_function, NULL, &timer_instance);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1137,12 +1137,12 @@ TEST_FUNCTION(threadpool_start_timer_with_NULL_work_function_context_succeeds)
     ASSERT_IS_NOT_NULL(timer_instance);
 
     // cleanup
-    threadpool_stop_timer(timer_instance);
+    threadpool_timer_destroy(timer_instance);
     threadpool_destroy(threadpool);
 }
 
-/* Tests_SRS_THREADPOOL_WIN32_42_008: [ If any error occurs, threadpool_start_timer shall fail and return a non-zero value. ]*/
-TEST_FUNCTION(threadpool_start_timer_fails_when_underlying_functions_fail)
+/* Tests_SRS_THREADPOOL_WIN32_42_008: [ If any error occurs, threadpool_timer_start shall fail and return a non-zero value. ]*/
+TEST_FUNCTION(threadpool_timer_start_fails_when_underlying_functions_fail)
 {
     // arrange
     PTP_CALLBACK_ENVIRON cbe;
@@ -1179,7 +1179,7 @@ TEST_FUNCTION(threadpool_start_timer_fails_when_underlying_functions_fail)
             umock_c_negative_tests_fail_call(i);
 
             // act
-            int result = threadpool_start_timer(threadpool, 42, 2000, test_work_function, (void*)0x4243, &timer_instance);
+            int result = threadpool_timer_start(threadpool, 42, 2000, test_work_function, (void*)0x4243, &timer_instance);
 
             // assert
             ASSERT_ARE_NOT_EQUAL(int, 0, result, "On failed call %zu", i);
@@ -1190,24 +1190,24 @@ TEST_FUNCTION(threadpool_start_timer_fails_when_underlying_functions_fail)
     threadpool_destroy(threadpool);
 }
 
-/* threadpool_restart_timer */
+/* threadpool_timer_restart */
 
-/* Tests_SRS_THREADPOOL_WIN32_42_019: [ If timer is NULL, threadpool_restart_timer shall fail and return a non-zero value. ]*/
-TEST_FUNCTION(threadpool_restart_timer_with_NULL_timer_fails)
+/* Tests_SRS_THREADPOOL_WIN32_42_019: [ If timer is NULL, threadpool_timer_restart shall fail and return a non-zero value. ]*/
+TEST_FUNCTION(threadpool_timer_restart_with_NULL_timer_fails)
 {
     // arrange
 
     // act
-    int result = threadpool_restart_timer(NULL, 43, 1000);
+    int result = threadpool_timer_restart(NULL, 43, 1000);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
 }
 
-/* Tests_SRS_THREADPOOL_WIN32_42_022: [ threadpool_restart_timer shall call SetThreadpoolTimer, passing negative start_delay_ms as pftDueTime, timer_period_ms as msPeriod, and 0 as msWindowLength. ]*/
-/* Tests_SRS_THREADPOOL_WIN32_42_023: [ threadpool_restart_timer shall succeed and return 0. ]*/
-TEST_FUNCTION(threadpool_restart_timer_succeeds)
+/* Tests_SRS_THREADPOOL_WIN32_42_022: [ threadpool_timer_restart shall call SetThreadpoolTimer, passing negative start_delay_ms as pftDueTime, timer_period_ms as msPeriod, and 0 as msWindowLength. ]*/
+/* Tests_SRS_THREADPOOL_WIN32_42_023: [ threadpool_timer_restart shall succeed and return 0. ]*/
+TEST_FUNCTION(threadpool_timer_restart_succeeds)
 {
     // arrange
     THREADPOOL_HANDLE threadpool;
@@ -1227,34 +1227,34 @@ TEST_FUNCTION(threadpool_restart_timer_succeeds)
         .ValidateArgumentValue_pti(&ptp_timer);
 
     // act
-    int result = threadpool_restart_timer(timer_instance, 43, 1000);
+    int result = threadpool_timer_restart(timer_instance, 43, 1000);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
     ASSERT_ARE_EQUAL(int, 0, result);
 
     // cleanup
-    threadpool_stop_timer(timer_instance);
+    threadpool_timer_destroy(timer_instance);
     threadpool_destroy(threadpool);
 }
 
-/* threadpool_cancel_timer */
+/* threadpool_timer_cancel */
 
-/*Tests_SRS_THREADPOOL_WIN32_42_024: [ If timer is NULL, threadpool_cancel_timer shall fail and return. ]*/
-TEST_FUNCTION(threadpool_cancel_timer_with_NULL_timer_fails)
+/*Tests_SRS_THREADPOOL_WIN32_42_024: [ If timer is NULL, threadpool_timer_cancel shall fail and return. ]*/
+TEST_FUNCTION(threadpool_timer_cancel_with_NULL_timer_fails)
 {
     // arrange
 
     // act
-    threadpool_cancel_timer(NULL);
+    threadpool_timer_cancel(NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-/*Tests_SRS_THREADPOOL_WIN32_42_025: [ threadpool_cancel_timer shall call SetThreadpoolTimer with NULL for pftDueTime and 0 for msPeriod and msWindowLength to cancel ongoing timers. ]*/
-/*Tests_SRS_THREADPOOL_WIN32_42_026: [ threadpool_cancel_timer shall call WaitForThreadpoolTimerCallbacks. ]*/
-TEST_FUNCTION(threadpool_cancel_timer_succeeds)
+/*Tests_SRS_THREADPOOL_WIN32_42_025: [ threadpool_timer_cancel shall call SetThreadpoolTimer with NULL for pftDueTime and 0 for msPeriod and msWindowLength to cancel ongoing timers. ]*/
+/*Tests_SRS_THREADPOOL_WIN32_42_026: [ threadpool_timer_cancel shall call WaitForThreadpoolTimerCallbacks. ]*/
+TEST_FUNCTION(threadpool_timer_cancel_succeeds)
 {
     // arrange
     THREADPOOL_HANDLE threadpool;
@@ -1268,35 +1268,35 @@ TEST_FUNCTION(threadpool_cancel_timer_succeeds)
     STRICT_EXPECTED_CALL(mocked_WaitForThreadpoolTimerCallbacks(ptp_timer, TRUE));
 
     // act
-    threadpool_cancel_timer(timer_instance);
+    threadpool_timer_cancel(timer_instance);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // cleanup
-    threadpool_stop_timer(timer_instance);
+    threadpool_timer_destroy(timer_instance);
     threadpool_destroy(threadpool);
 }
 
-/* threadpool_stop_timer */
+/* threadpool_timer_destroy */
 
-/* Tests_SRS_THREADPOOL_WIN32_42_011: [ If timer is NULL, threadpool_stop_timer shall fail and return. ]*/
-TEST_FUNCTION(threadpool_stop_timer_with_NULL_timer_fails)
+/* Tests_SRS_THREADPOOL_WIN32_42_011: [ If timer is NULL, threadpool_timer_destroy shall fail and return. ]*/
+TEST_FUNCTION(threadpool_timer_destroy_with_NULL_timer_fails)
 {
     // arrange
 
     // act
-    threadpool_stop_timer(NULL);
+    threadpool_timer_destroy(NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-/* Tests_SRS_THREADPOOL_WIN32_42_012: [ threadpool_stop_timer shall call SetThreadpoolTimer with NULL for pftDueTime and 0 for msPeriod and msWindowLength to cancel ongoing timers. ]*/
-/* Tests_SRS_THREADPOOL_WIN32_42_013: [ threadpool_stop_timer shall call WaitForThreadpoolTimerCallbacks. ]*/
-/* Tests_SRS_THREADPOOL_WIN32_42_014: [ threadpool_stop_timer shall call CloseThreadpoolTimer. ]*/
-/* Tests_SRS_THREADPOOL_WIN32_42_015: [ threadpool_stop_timer shall free all resources in timer. ]*/
-TEST_FUNCTION(threadpool_stop_timer_succeeds)
+/* Tests_SRS_THREADPOOL_WIN32_42_012: [ threadpool_timer_destroy shall call SetThreadpoolTimer with NULL for pftDueTime and 0 for msPeriod and msWindowLength to cancel ongoing timers. ]*/
+/* Tests_SRS_THREADPOOL_WIN32_42_013: [ threadpool_timer_destroy shall call WaitForThreadpoolTimerCallbacks. ]*/
+/* Tests_SRS_THREADPOOL_WIN32_42_014: [ threadpool_timer_destroy shall call CloseThreadpoolTimer. ]*/
+/* Tests_SRS_THREADPOOL_WIN32_42_015: [ threadpool_timer_destroy shall free all resources in timer. ]*/
+TEST_FUNCTION(threadpool_timer_destroy_succeeds)
 {
     // arrange
     THREADPOOL_HANDLE threadpool;
@@ -1312,7 +1312,7 @@ TEST_FUNCTION(threadpool_stop_timer_succeeds)
     STRICT_EXPECTED_CALL(free(IGNORED_ARG));
 
     // act
-    threadpool_stop_timer(timer_instance);
+    threadpool_timer_destroy(timer_instance);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1341,7 +1341,7 @@ TEST_FUNCTION(on_timer_callback_with_NULL_context_returns)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // cleanup
-    threadpool_stop_timer(timer_instance);
+    threadpool_timer_destroy(timer_instance);
     threadpool_destroy(threadpool);
 }
 
@@ -1366,7 +1366,7 @@ TEST_FUNCTION(on_timer_callback_calls_user_callback)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // cleanup
-    threadpool_stop_timer(timer_instance);
+    threadpool_timer_destroy(timer_instance);
     threadpool_destroy(threadpool);
 }
 
@@ -1399,7 +1399,7 @@ TEST_FUNCTION(on_timer_callback_calls_user_callback_multiple_times_as_timer_fire
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // cleanup
-    threadpool_stop_timer(timer_instance);
+    threadpool_timer_destroy(timer_instance);
     threadpool_destroy(threadpool);
 }
 


### PR DESCRIPTION
Make threadpool timers more re-usable by adding a cancel (which does part of stop without freeing resources) and restart (which changes the delay and period of a created timer) to them.