### PR TITLE
Helper for refcount reals

### DIFF
--- a/common/reals/real_refcount.h
+++ b/common/reals/real_refcount.h
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+#ifndef REAL_REFCOUNT_H
+#define REAL_REFCOUNT_H
+
+#include "c_pal/refcount.h"
+
+#include "real_interlocked.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// When this file is included, test types defined as refcount types will not generate mock calls to interlocked
+
+//#undef INC_REF
+//#define INC_REF(type, var) real_interlocked_increment(&((REFCOUNT_TYPE(type)*)((unsigned char*)var - offsetof(REFCOUNT_TYPE(type), counted)))->count)
+//#undef DEC_REF
+//#define DEC_REF(type, var) real_interlocked_decrement(&((REFCOUNT_TYPE(type)*)((unsigned char*)var - offsetof(REFCOUNT_TYPE(type), counted)))->count)
+//#undef INIT_REF
+//#define INIT_REF(type, var) real_interlocked_exchange(&((REFCOUNT_TYPE(type)*)((unsigned char*)var - offsetof(REFCOUNT_TYPE(type), counted)))->count, 1)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //REAL_REFCOUNT_H

--- a/common/reals/real_refcount.h
+++ b/common/reals/real_refcount.h
@@ -13,12 +13,12 @@ extern "C" {
 
 // When this file is included, test types defined as refcount types will not generate mock calls to interlocked
 
-//#undef INC_REF
-//#define INC_REF(type, var) real_interlocked_increment(&((REFCOUNT_TYPE(type)*)((unsigned char*)var - offsetof(REFCOUNT_TYPE(type), counted)))->count)
-//#undef DEC_REF
-//#define DEC_REF(type, var) real_interlocked_decrement(&((REFCOUNT_TYPE(type)*)((unsigned char*)var - offsetof(REFCOUNT_TYPE(type), counted)))->count)
-//#undef INIT_REF
-//#define INIT_REF(type, var) real_interlocked_exchange(&((REFCOUNT_TYPE(type)*)((unsigned char*)var - offsetof(REFCOUNT_TYPE(type), counted)))->count, 1)
+#undef INC_REF
+#define INC_REF(type, var) real_interlocked_increment(&((REFCOUNT_TYPE(type)*)((unsigned char*)var - offsetof(REFCOUNT_TYPE(type), counted)))->count)
+#undef DEC_REF
+#define DEC_REF(type, var) real_interlocked_decrement(&((REFCOUNT_TYPE(type)*)((unsigned char*)var - offsetof(REFCOUNT_TYPE(type), counted)))->count)
+#undef INIT_REF
+#define INIT_REF(type, var) real_interlocked_exchange(&((REFCOUNT_TYPE(type)*)((unsigned char*)var - offsetof(REFCOUNT_TYPE(type), counted)))->count, 1)
 
 #ifdef __cplusplus
 }

--- a/linux/linux_reals/CMakeLists.txt
+++ b/linux/linux_reals/CMakeLists.txt
@@ -13,9 +13,10 @@ set(linux_reals_c_files
 set(linux_reals_h_files
     real_interlocked_renames.h
     real_interlocked.h
+    ../../common/reals/real_refcount.h
 )
 
 include_directories(${CMAKE_CURRENT_LIST_DIR}/../../src)
 add_library(linux_reals ${linux_reals_c_files} ${linux_reals_h_files})
-target_include_directories(linux_reals PUBLIC .)
+target_include_directories(linux_reals PUBLIC . ${CMAKE_CURRENT_LIST_DIR}/../../common/reals)
 target_link_libraries(linux_reals pal_interfaces pal_interfaces_reals rt uuid pthread)

--- a/win32/reals/CMakeLists.txt
+++ b/win32/reals/CMakeLists.txt
@@ -22,10 +22,11 @@ set(reals_win32_h_files
     real_interlocked_renames.h
     real_lazy_init.h
     real_lazy_init_renames.h
+    ../../common/reals/real_refcount.h
 )
 
 add_library(win32_reals ${reals_win32_c_files} ${reals_win32_h_files})
-target_include_directories(win32_reals PUBLIC . ${CMAKE_CURRENT_LIST_DIR}/../src "$<TARGET_PROPERTY:pal_win32,INTERFACE_INCLUDE_DIRECTORIES>")
+target_include_directories(win32_reals PUBLIC . ${CMAKE_CURRENT_LIST_DIR}/../../common/reals ${CMAKE_CURRENT_LIST_DIR}/../src "$<TARGET_PROPERTY:pal_win32,INTERFACE_INCLUDE_DIRECTORIES>")
 target_link_libraries(win32_reals pal_interfaces_reals synchronization)
 
 if(${GBALLOC_LL_TYPE} STREQUAL "MIMALLOC")

--- a/win32/reals/real_interlocked.h
+++ b/win32/reals/real_interlocked.h
@@ -12,6 +12,7 @@
 #endif
 
 #include "macro_utils/macro_utils.h"
+#include "c_pal/interlocked.h"
 
 #define R2(X) REGISTER_GLOBAL_MOCK_HOOK(X, real_##X);
 
@@ -98,7 +99,7 @@ int8_t real_interlocked_or_8(volatile_atomic int8_t* destination, int8_t value);
 int32_t real_interlocked_xor(volatile_atomic int32_t* destination, int32_t value);
 int16_t real_interlocked_xor_16(volatile_atomic int16_t* destination, int16_t value);
 int64_t real_interlocked_xor_64(volatile_atomic int64_t* destination, int64_t value);
-int8_t real_interlocked_xor_8(volatile_atomic int8_t* destination, int8_t value); 
+int8_t real_interlocked_xor_8(volatile_atomic int8_t* destination, int8_t value);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Adds a header for using refcount types in tests with mocks without generating interlocked mock calls.
Unit tests should include real_refcount.h before `DEFINE_REFCOUNT_TYPE_WITH_CUSTOM_ALLOC`