### PR TITLE
fix test lib names

### DIFF
--- a/win32/tests/gballoc_hl_int/CMakeLists.txt
+++ b/win32/tests/gballoc_hl_int/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 set(theseTestsNameBase gballoc_hl_int) 
 
-set(theseTestsName ${theseTestsNameBase}_${BINARY_DIR})
+set(theseTestsName ${theseTestsNameBase}_${BINARY_DIR}_int)
 
 set(${theseTestsName}_test_files
     ${theseTestsNameBase}.c


### PR DESCRIPTION
Appending `_int` to gballoc_int tests so that they get filtered out for real check.