### PR TITLE
Add execution_engine_inc_ref to threadpool

### DIFF
--- a/win32/devdoc/threadpool_win32.md
+++ b/win32/devdoc/threadpool_win32.md
@@ -52,6 +52,8 @@ MOCKABLE_FUNCTION(, THREADPOOL_HANDLE, threadpool_create, EXECUTION_ENGINE_HANDL
 
 **SRS_THREADPOOL_WIN32_01_002: [** If `execution_engine` is `NULL`, `threadpool_create` shall fail and return `NULL`. **]**
 
+**SRS_THREADPOOL_WIN32_42_027: [** `threadpool_create` shall increment the reference count on the `execution_engine`. **]**
+
 **SRS_THREADPOOL_WIN32_01_025: [** `threadpool_create` shall obtain the PTP_POOL from the execution engine by calling `execution_engine_win32_get_threadpool`. **]**
 
 **SRS_THREADPOOL_WIN32_01_003: [** If any error occurs, `threadpool_create` shall fail and return `NULL`. **]**
@@ -71,6 +73,8 @@ MOCKABLE_FUNCTION(, void, threadpool_destroy, THREADPOOL_HANDLE, threadpool);
 **SRS_THREADPOOL_WIN32_01_006: [** While `threadpool` is OPENING or CLOSING, `threadpool_destroy` shall wait for the open to complete either successfully or with error. **]**
 
 **SRS_THREADPOOL_WIN32_01_007: [** `threadpool_destroy` shall perform an implicit close if `threadpool` is OPEN. **]**
+
+**SRS_THREADPOOL_WIN32_42_028: [** `threadpool_destroy` shall decrement the reference count on the `execution_engine`. **]**
 
 ### threadpool_open_async
 

--- a/win32/tests/threadpool_win32_ut/threadpool_win32_ut.c
+++ b/win32/tests/threadpool_win32_ut/threadpool_win32_ut.c
@@ -323,6 +323,7 @@ TEST_FUNCTION(threadpool_create_with_NULL_execution_engine_fails)
 }
 
 /* Tests_SRS_THREADPOOL_WIN32_01_001: [ threadpool_create shall allocate a new threadpool object and on success shall return a non-NULL handle. ]*/
+/* Tests_SRS_THREADPOOL_WIN32_42_027: [ threadpool_create shall increment the reference count on the execution_engine. ]*/
 /* Tests_SRS_THREADPOOL_WIN32_01_025: [ threadpool_create shall obtain the PTP_POOL from the execution engine by calling execution_engine_win32_get_threadpool. ]*/
 TEST_FUNCTION(threadpool_create_succeeds)
 {
@@ -331,6 +332,7 @@ TEST_FUNCTION(threadpool_create_succeeds)
 
     STRICT_EXPECTED_CALL(malloc(IGNORED_ARG));
     STRICT_EXPECTED_CALL(execution_engine_win32_get_threadpool(test_execution_engine));
+    STRICT_EXPECTED_CALL(execution_engine_inc_ref(test_execution_engine));
 
     // act
     threadpool = threadpool_create(test_execution_engine);
@@ -352,6 +354,7 @@ TEST_FUNCTION(when_underlying_calls_fail_threadpool_create_fails)
 
     STRICT_EXPECTED_CALL(malloc(IGNORED_ARG));
     STRICT_EXPECTED_CALL(execution_engine_win32_get_threadpool(test_execution_engine));
+    STRICT_EXPECTED_CALL(execution_engine_inc_ref(test_execution_engine));
 
     umock_c_negative_tests_snapshot();
 
@@ -386,12 +389,14 @@ TEST_FUNCTION(threadpool_destroy_with_NULL_threadpool_returns)
 }
 
 /* Tests_SRS_THREADPOOL_WIN32_01_005: [ Otherwise, threadpool_destroy shall free all resources associated with threadpool. ]*/
+/* Tests_SRS_THREADPOOL_WIN32_42_028: [ threadpool_destroy shall decrement the reference count on the execution_engine. ]*/
 TEST_FUNCTION(threadpool_destroy_frees_resources)
 {
     // arrange
     THREADPOOL_HANDLE threadpool = threadpool_create(test_execution_engine);
     umock_c_reset_all_calls();
 
+    STRICT_EXPECTED_CALL(execution_engine_dec_ref(test_execution_engine));
     STRICT_EXPECTED_CALL(free(IGNORED_ARG));
 
     // act
@@ -426,6 +431,7 @@ TEST_FUNCTION(threadpool_destroy_performs_an_implicit_close)
     STRICT_EXPECTED_CALL(mocked_DestroyThreadpoolEnvironment(cbe));
 
     // destroy calls
+    STRICT_EXPECTED_CALL(execution_engine_dec_ref(test_execution_engine));
     STRICT_EXPECTED_CALL(free(IGNORED_ARG));
 
     // act


### PR DESCRIPTION
Previously, this code would get stuck:

```c
EXECUTION_ENGINE_HANDLE execution_engine = execution_engine_create(NULL);
THREADPOOL_HANDLE threadpool = threadpool_create(execution_engine);
execution_engine_dec_ref(execution_engine); // this is the last reference even though threadpool needs it!
(void)threadpool_open_async(threadpool, on_open_complete, &open_event);
// wait for open
threadpool_schedule_work(threadpool, work_function, NULL); // gets stuck!
```

Really, the threadpool needs to hold a reference to the execution engine and not rely on the caller to do that.