### PR TITLE
srw lock ll specs

### DIFF
--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -11,6 +11,7 @@ set(pal_interfaces_h_files
     inc/c_pal/timer.h
     inc/c_pal/uuid.h
     inc/c_pal/srw_lock.h
+    inc/c_pal/srw_lock_ll.h
     inc/c_pal/file.h
     inc/c_pal/gballoc_ll.h
     inc/c_pal/gballoc_ll_redirects.h

--- a/interfaces/devdoc/srw_lock_ll_requirements.md
+++ b/interfaces/devdoc/srw_lock_ll_requirements.md
@@ -4,6 +4,10 @@
 
 `srw_lock_ll` is the implementation of a slim reader writer lock.
 
+References:
+
+[https://learn.microsoft.com/en-us/windows/win32/sync/slim-reader-writer--srw--locks](https://learn.microsoft.com/en-us/windows/win32/sync/slim-reader-writer--srw--locks)
+
 ## Exposed API
 
 ```c
@@ -12,11 +16,9 @@
     SRW_LOCK_LL_TRY_ACQUIRE_COULD_NOT_ACQUIRE, \
     SRW_LOCK_LL_TRY_ACQUIRE_INVALID_ARGS
 
-typedef void* SRW_LOCK_LL;
-
 MU_DEFINE_ENUM(SRW_LOCK_LL_TRY_ACQUIRE_RESULT, SRW_LOCK_LL_TRY_ACQUIRE_RESULT_VALUES)
 
-MOCKABLE_FUNCTION(, void, srw_lock_ll_init);
+MOCKABLE_FUNCTION(, int, srw_lock_ll_init, SRW_LOCK_LL*, srw_lock_ll);
 MOCKABLE_FUNCTION(, void, srw_lock_ll_deinit, SRW_LOCK_LL*, srw_lock_ll);
 
 /*writer APIs*/
@@ -30,6 +32,8 @@ MOCKABLE_FUNCTION(, SRW_LOCK_LL_TRY_ACQUIRE_RESULT, srw_lock_ll_try_acquire_shar
 MOCKABLE_FUNCTION(, void, srw_lock_ll_release_shared, SRW_LOCK_LL*, srw_lock_ll);
 ```
 
+Note that the type `SRW_LOCK_LL` is defined individually for each platform.
+
 ### srw_lock_ll_init
 ```c
 MOCKABLE_FUNCTION(, void, srw_lock_ll_init, SRW_LOCK_LL*, srw_lock_ll);
@@ -42,7 +46,7 @@ MOCKABLE_FUNCTION(, void, srw_lock_ll_init, SRW_LOCK_LL*, srw_lock_ll);
 MOCKABLE_FUNCTION(, void, srw_lock_ll_deinit, SRW_LOCK_LL*, srw_lock_ll);
 ```
 
-`srw_lock_ll_deinit` frees deinitializes the slim reader writer lock.
+`srw_lock_ll_deinit` deinitializes the slim reader writer lock.
 
 ### srw_lock_ll_acquire_exclusive
 ```c
@@ -71,7 +75,7 @@ MOCKABLE_FUNCTION(, void, srw_lock_ll_release_exclusive, SRW_LOCK_LL*, srw_lock_
 MOCKABLE_FUNCTION(, void, srw_lock_ll_acquire_shared, SRW_LOCK_LL*, srw_lock_ll);
 ```
 
-`srw_lock_ll_acquire_shared` acquires the SRWLOCK in shared (read) mode.
+`srw_lock_ll_acquire_shared` acquires the slim reader writer lock in shared (read) mode.
 
 ### srw_lock_ll_try_acquire_shared
 ```c

--- a/interfaces/devdoc/srw_lock_ll_requirements.md
+++ b/interfaces/devdoc/srw_lock_ll_requirements.md
@@ -1,8 +1,8 @@
-# `srw_lock` requirements
+# `srw_lock_ll` requirements
 
 ## Overview
 
-`srw_lock` is a wrapper over a `SRWLOCK` with the additional benefit of having some statistics printed.
+`srw_lock_ll` is the implementation of a slim reader writer lock (on Windows it simply wraps`SRWLOCK`).
 
 ## Exposed API
 
@@ -20,7 +20,7 @@ MOCKABLE_FUNCTION(, void, srw_lock_ll_init);
 MOCKABLE_FUNCTION(, void, srw_lock_ll_deinit, SRW_LOCK_LL*, srw_lock_ll);
 
 /*writer APIs*/
-MOCKABLE_FUNCTION(, void, srw_lock_ll_acquire_exclusive, SRW_LOCK_LL*, handle);
+MOCKABLE_FUNCTION(, void, srw_lock_ll_acquire_exclusive, SRW_LOCK_LL*, srw_lock_ll);
 MOCKABLE_FUNCTION(, SRW_LOCK_LL_TRY_ACQUIRE_RESULT, srw_lock_ll_try_acquire_exclusive, SRW_LOCK_LL*, srw_lock_ll);
 MOCKABLE_FUNCTION(, void, srw_lock_ll_release_exclusive, SRW_LOCK_LL*, srw_lock_ll);
 
@@ -35,111 +35,91 @@ MOCKABLE_FUNCTION(, void, srw_lock_ll_release_shared, SRW_LOCK_LL*, srw_lock_ll)
 MOCKABLE_FUNCTION(, void, srw_lock_ll_init, SRW_LOCK_LL*, srw_lock_ll);
 ```
 
-`srw_lock_ll_init` initializes a new SRW lock.
+`srw_lock_ll_init` initializes a slim reader writer lock.
 
 If `srw_lock_ll` is `NULL`, `srw_lock_ll_init` shall return.
 
 Otherwise, `srw_lock_ll_init` shall call `InitializeSRWLock`.
 
-**SRS_SRW_LOCK_02_023: [** If `do_statistics` is `true` then `srw_lock_create` shall copy `lock_name`.  **]**
-
-**SRS_SRW_LOCK_02_024: [** If `do_statistics` is `true` then `srw_lock_create` shall create a new `TIMER_HANDLE` by calling `timer_create_new`. **]**
-
-**SRS_SRW_LOCK_02_003: [** `srw_lock_create` shall succeed and return a non-`NULL` value. **]**
-
-**SRS_SRW_LOCK_02_004: [** If there are any failures then `srw_lock_create` shall fail and return `NULL`. **]**
-
-### srw_lock_acquire_exclusive
+### srw_lock_ll_deinit
 ```c
-MOCKABLE_FUNCTION(, void, srw_lock_acquire_exclusive, SRW_LOCK_HANDLE, handle);
+MOCKABLE_FUNCTION(, void, srw_lock_ll_deinit, SRW_LOCK_LL*, srw_lock_ll);
 ```
 
-`srw_lock_acquire_exclusive` acquires the lock in exclusive (writer) mode.
+`srw_lock_ll_deinit` frees deinitializes the slim reader writer lock.
 
-**SRS_SRW_LOCK_02_022: [** If `handle` is `NULL` then `srw_lock_acquire_exclusive` shall return. **]**
+If `srw_lock_ll` is `NULL` then `srw_lock_ll_deinit` shall return.
 
-**SRS_SRW_LOCK_02_006: [** `srw_lock_acquire_exclusive` shall call `AcquireSRWLockExclusive`. **]**
+Otherwise, `srw_lock_ll_deinit` shall return.
 
-**SRS_SRW_LOCK_02_025: [** If `do_statistics` is `true` and if the timer created has recorded more than `TIME_BETWEEN_STATISTICS_LOG` seconds then statistics will be logged and the timer shall be started again. **]**
-
-### srw_lock_try_acquire_exclusive
+### srw_lock_ll_acquire_exclusive
 ```c
-MOCKABLE_FUNCTION(, SRW_LOCK_TRY_ACQUIRE_RESULT, srw_lock_try_acquire_exclusive, SRW_LOCK_HANDLE, handle);
+MOCKABLE_FUNCTION(, void, srw_lock_ll_acquire_exclusive, SRW_LOCK_LL*, srw_lock_ll);
 ```
 
-`srw_lock_try_acquire_exclusive` attempts to acquire the lock in exclusive (writer) mode.
+`srw_lock_ll_acquire_exclusive` acquires the slim reader writer lock in exclusive (writer) mode.
 
-**SRS_SRW_LOCK_01_006: [** If `handle` is `NULL` then `srw_lock_try_acquire_exclusive` shall fail and return `SRW_LOCK_TRY_ACQUIRE_INVALID_ARGS`. **]**
+If `srw_lock_ll` is `NULL` then `srw_lock_ll_acquire_exclusive` shall return.
 
-**SRS_SRW_LOCK_01_007: [** Otherwise `srw_lock_acquire_exclusive` shall call `TryAcquireSRWLockExclusive`. **]**
+`srw_lock_ll_acquire_exclusive` shall call `AcquireSRWLockExclusive`.
 
-**SRS_SRW_LOCK_01_008: [** If `TryAcquireSRWLockExclusive` returns `FALSE`, `srw_lock_acquire_exclusive` shall return `SRW_LOCK_TRY_ACQUIRE_COULD_NOT_ACQUIRE`. **]**
-
-**SRS_SRW_LOCK_01_009: [** If `TryAcquireSRWLockExclusive` returns `TRUE`, `srw_lock_acquire_exclusive` shall return `SRW_LOCK_TRY_ACQUIRE_OK`. **]**
-
-**SRS_SRW_LOCK_01_010: [** If `do_statistics` is `true` and if the timer created has recorded more than `TIME_BETWEEN_STATISTICS_LOG` seconds then statistics will be logged and the timer shall be started again. **]**
-
-### srw_lock_release_exclusive
+### srw_lock_ll_try_acquire_exclusive
 ```c
-MOCKABLE_FUNCTION(, void, srw_lock_release_exclusive, SRW_LOCK_HANDLE, handle);
+MOCKABLE_FUNCTION(, SRW_LOCK_LL_TRY_ACQUIRE_RESULT, srw_lock_ll_try_acquire_exclusive, SRW_LOCK_LL*, srw_lock_ll);
 ```
 
-`srw_lock_release_exclusive` releases the underlying `SRWLOCK` from exclusive (write) mode.
+`srw_lock_ll_try_acquire_exclusive` attempts to acquire the slim reader writer lock in exclusive (writer) mode.
 
-**SRS_SRW_LOCK_02_009: [** If `handle` is `NULL` then `srw_lock_release_exclusive` shall return. **]**
+If `srw_lock_ll` is `NULL` then `srw_lock_ll_try_acquire_exclusive` shall fail and return `SRW_LOCK_TRY_ACQUIRE_INVALID_ARGS`.
 
-**SRS_SRW_LOCK_02_010: [** `srw_lock_release_exclusive` shall call `ReleaseSRWLockExclusive`. **]**
+Otherwise `srw_lock_ll_try_acquire_exclusive` shall call `TryAcquireSRWLockExclusive`.
 
+If `TryAcquireSRWLockExclusive` returns `FALSE`, `srw_lock_ll_try_acquire_exclusive` shall return `SRW_LOCK_LL_TRY_ACQUIRE_COULD_NOT_ACQUIRE`.
 
-### srw_lock_acquire_shared
+If `TryAcquireSRWLockExclusive` returns `TRUE`, `srw_lock_ll_try_acquire_exclusive` shall return `SRW_LOCK_LL_TRY_ACQUIRE_OK`.
+
+### srw_lock_ll_release_exclusive
 ```c
-MOCKABLE_FUNCTION(, void, srw_lock_acquire_shared, SRW_LOCK_HANDLE, handle);
+MOCKABLE_FUNCTION(, void, srw_lock_ll_release_exclusive, SRW_LOCK_LL*, srw_lock_ll);
 ```
 
-`srw_lock_acquire_shared` acquires the SRWLOCK in shared (read) mode.
+`srw_lock_release_exclusive` releases the underlying slim reader writer lock from exclusive (write) mode.
 
-**SRS_SRW_LOCK_02_017: [** If `handle` is `NULL` then `srw_lock_acquire_shared` shall return. **]**
+If `srw_lock_ll` is `NULL` then `srw_lock_ll_release_exclusive` shall return.
 
-**SRS_SRW_LOCK_02_018: [** `srw_lock_acquire_shared` shall call `AcquireSRWLockShared`. **]**
+`srw_lock_ll_release_exclusive` shall call `ReleaseSRWLockExclusive`.
 
-**SRS_SRW_LOCK_02_026: [** If `do_statistics` is `true` and the timer created has recorded more than `TIME_BETWEEN_STATISTICS_LOG` seconds then statistics will be logged and the timer shall be started again. **]**
-
-### srw_lock_try_acquire_shared
+### srw_lock_ll_acquire_shared
 ```c
-MOCKABLE_FUNCTION(, SRW_LOCK_TRY_ACQUIRE_RESULT, srw_lock_try_acquire_shared, SRW_LOCK_HANDLE, handle);
+MOCKABLE_FUNCTION(, void, srw_lock_ll_acquire_shared, SRW_LOCK_LL*, srw_lock_ll);
 ```
 
-`srw_lock_try_acquire_shared` attempts to acquire the SRWLOCK in shared (read) mode.
+`srw_lock_ll_acquire_shared` acquires the SRWLOCK in shared (read) mode.
 
-**SRS_SRW_LOCK_01_001: [** If `handle` is `NULL` then `srw_lock_try_acquire_shared` shall fail and return `SRW_LOCK_TRY_ACQUIRE_INVALID_ARGS`. **]**
+If `srw_lock_ll` is `NULL` then `srw_lock_ll_acquire_shared` shall return.
 
-**SRS_SRW_LOCK_01_002: [** Otherwise `srw_lock_try_acquire_shared` shall call `TryAcquireSRWLockShared`. **]**
+`srw_lock_ll_acquire_shared` shall call `AcquireSRWLockShared`.
 
-**SRS_SRW_LOCK_01_003: [** If `TryAcquireSRWLockShared` returns `FALSE`, `srw_lock_try_acquire_shared` shall return `SRW_LOCK_TRY_ACQUIRE_COULD_NOT_ACQUIRE`. **]**
-
-**SRS_SRW_LOCK_01_004: [** If `TryAcquireSRWLockShared` returns `TRUE`, `srw_lock_try_acquire_shared` shall return `SRW_LOCK_TRY_ACQUIRE_OK`. **]**
-
-**SRS_SRW_LOCK_01_005: [** If `do_statistics` is `true` and the timer created has recorded more than `TIME_BETWEEN_STATISTICS_LOG` seconds then statistics will be logged and the timer shall be started again. **]**
-
-
-### srw_lock_release_shared
+### srw_lock_ll_try_acquire_shared
 ```c
-MOCKABLE_FUNCTION(, void, srw_lock_release_shared, SRW_LOCK_HANDLE, handle);
+MOCKABLE_FUNCTION(, SRW_LOCK_LL_TRY_ACQUIRE_RESULT, srw_lock_ll_try_acquire_shared, SRW_LOCK_LL*, srw_lock_ll);
 ```
 
-**SRS_SRW_LOCK_02_020: [** If `handle` is `NULL` then `srw_lock_release_shared` shall return. **]**
+`srw_lock_ll_try_acquire_shared` attempts to acquire the slim reader writer lock in shared (read) mode.
 
-**SRS_SRW_LOCK_02_021: [** `srw_lock_release_shared` shall call `ReleaseSRWLockShared`. **]**
+If `srw_lock_ll` is `NULL` then `srw_lock_ll_try_acquire_shared` shall fail and return `SRW_LOCK_LL_TRY_ACQUIRE_INVALID_ARGS`.
 
+Otherwise `srw_lock_ll_try_acquire_shared` shall call `TryAcquireSRWLockShared`.
 
-### srw_lock_destroy
+If `TryAcquireSRWLockShared` returns `FALSE`, `srw_lock_ll_try_acquire_shared` shall return `SRW_LOCK_LL_TRY_ACQUIRE_COULD_NOT_ACQUIRE`.
+
+If `TryAcquireSRWLockShared` returns `TRUE`, `srw_lock_ll_try_acquire_shared` shall return `SRW_LOCK_LL_TRY_ACQUIRE_OK`.
+
+### srw_lock_ll_release_shared
 ```c
-MOCKABLE_FUNCTION(, void, srw_lock_destroy, SRW_LOCK_HANDLE, handle);
+MOCKABLE_FUNCTION(, void, srw_lock_ll_release_shared, SRW_LOCK_LL*, srw_lock_ll);
 ```
 
-`srw_lock_destroy` frees all used resources.
+If `srw_lock_ll` is `NULL` then `srw_lock_ll_release_shared` shall return.
 
-**SRS_SRW_LOCK_02_011: [** If `handle` is `NULL` then `srw_lock_destroy` shall return. **]**
-
-**SRS_SRW_LOCK_02_012: [** `srw_lock_destroy` shall free all used resources. **]**
-
+`srw_lock_ll_release_shared` shall call `ReleaseSRWLockShared`.

--- a/interfaces/devdoc/srw_lock_ll_requirements.md
+++ b/interfaces/devdoc/srw_lock_ll_requirements.md
@@ -1,0 +1,145 @@
+# `srw_lock` requirements
+
+## Overview
+
+`srw_lock` is a wrapper over a `SRWLOCK` with the additional benefit of having some statistics printed.
+
+## Exposed API
+
+```c
+#define SRW_LOCK_LL_TRY_ACQUIRE_RESULT_VALUES \
+    SRW_LOCK_LL_TRY_ACQUIRE_OK, \
+    SRW_LOCK_LL_TRY_ACQUIRE_COULD_NOT_ACQUIRE, \
+    SRW_LOCK_LL_TRY_ACQUIRE_INVALID_ARGS
+
+typedef void* SRW_LOCK_LL;
+
+MU_DEFINE_ENUM(SRW_LOCK_LL_TRY_ACQUIRE_RESULT, SRW_LOCK_LL_TRY_ACQUIRE_RESULT_VALUES)
+
+MOCKABLE_FUNCTION(, void, srw_lock_ll_init);
+MOCKABLE_FUNCTION(, void, srw_lock_ll_deinit, SRW_LOCK_LL*, srw_lock_ll);
+
+/*writer APIs*/
+MOCKABLE_FUNCTION(, void, srw_lock_ll_acquire_exclusive, SRW_LOCK_LL*, handle);
+MOCKABLE_FUNCTION(, SRW_LOCK_LL_TRY_ACQUIRE_RESULT, srw_lock_ll_try_acquire_exclusive, SRW_LOCK_LL*, srw_lock_ll);
+MOCKABLE_FUNCTION(, void, srw_lock_ll_release_exclusive, SRW_LOCK_LL*, srw_lock_ll);
+
+/*reader APIs*/
+MOCKABLE_FUNCTION(, void, srw_lock_ll_acquire_shared, SRW_LOCK_LL*, srw_lock_ll);
+MOCKABLE_FUNCTION(, SRW_LOCK_LL_TRY_ACQUIRE_RESULT, srw_lock_ll_try_acquire_shared, SRW_LOCK_LL*, srw_lock_ll);
+MOCKABLE_FUNCTION(, void, srw_lock_ll_release_shared, SRW_LOCK_LL*, srw_lock_ll);
+```
+
+### srw_lock_ll_init
+```c
+MOCKABLE_FUNCTION(, void, srw_lock_ll_init, SRW_LOCK_LL*, srw_lock_ll);
+```
+
+`srw_lock_ll_init` initializes a new SRW lock.
+
+If `srw_lock_ll` is `NULL`, `srw_lock_ll_init` shall return.
+
+Otherwise, `srw_lock_ll_init` shall call `InitializeSRWLock`.
+
+**SRS_SRW_LOCK_02_023: [** If `do_statistics` is `true` then `srw_lock_create` shall copy `lock_name`.  **]**
+
+**SRS_SRW_LOCK_02_024: [** If `do_statistics` is `true` then `srw_lock_create` shall create a new `TIMER_HANDLE` by calling `timer_create_new`. **]**
+
+**SRS_SRW_LOCK_02_003: [** `srw_lock_create` shall succeed and return a non-`NULL` value. **]**
+
+**SRS_SRW_LOCK_02_004: [** If there are any failures then `srw_lock_create` shall fail and return `NULL`. **]**
+
+### srw_lock_acquire_exclusive
+```c
+MOCKABLE_FUNCTION(, void, srw_lock_acquire_exclusive, SRW_LOCK_HANDLE, handle);
+```
+
+`srw_lock_acquire_exclusive` acquires the lock in exclusive (writer) mode.
+
+**SRS_SRW_LOCK_02_022: [** If `handle` is `NULL` then `srw_lock_acquire_exclusive` shall return. **]**
+
+**SRS_SRW_LOCK_02_006: [** `srw_lock_acquire_exclusive` shall call `AcquireSRWLockExclusive`. **]**
+
+**SRS_SRW_LOCK_02_025: [** If `do_statistics` is `true` and if the timer created has recorded more than `TIME_BETWEEN_STATISTICS_LOG` seconds then statistics will be logged and the timer shall be started again. **]**
+
+### srw_lock_try_acquire_exclusive
+```c
+MOCKABLE_FUNCTION(, SRW_LOCK_TRY_ACQUIRE_RESULT, srw_lock_try_acquire_exclusive, SRW_LOCK_HANDLE, handle);
+```
+
+`srw_lock_try_acquire_exclusive` attempts to acquire the lock in exclusive (writer) mode.
+
+**SRS_SRW_LOCK_01_006: [** If `handle` is `NULL` then `srw_lock_try_acquire_exclusive` shall fail and return `SRW_LOCK_TRY_ACQUIRE_INVALID_ARGS`. **]**
+
+**SRS_SRW_LOCK_01_007: [** Otherwise `srw_lock_acquire_exclusive` shall call `TryAcquireSRWLockExclusive`. **]**
+
+**SRS_SRW_LOCK_01_008: [** If `TryAcquireSRWLockExclusive` returns `FALSE`, `srw_lock_acquire_exclusive` shall return `SRW_LOCK_TRY_ACQUIRE_COULD_NOT_ACQUIRE`. **]**
+
+**SRS_SRW_LOCK_01_009: [** If `TryAcquireSRWLockExclusive` returns `TRUE`, `srw_lock_acquire_exclusive` shall return `SRW_LOCK_TRY_ACQUIRE_OK`. **]**
+
+**SRS_SRW_LOCK_01_010: [** If `do_statistics` is `true` and if the timer created has recorded more than `TIME_BETWEEN_STATISTICS_LOG` seconds then statistics will be logged and the timer shall be started again. **]**
+
+### srw_lock_release_exclusive
+```c
+MOCKABLE_FUNCTION(, void, srw_lock_release_exclusive, SRW_LOCK_HANDLE, handle);
+```
+
+`srw_lock_release_exclusive` releases the underlying `SRWLOCK` from exclusive (write) mode.
+
+**SRS_SRW_LOCK_02_009: [** If `handle` is `NULL` then `srw_lock_release_exclusive` shall return. **]**
+
+**SRS_SRW_LOCK_02_010: [** `srw_lock_release_exclusive` shall call `ReleaseSRWLockExclusive`. **]**
+
+
+### srw_lock_acquire_shared
+```c
+MOCKABLE_FUNCTION(, void, srw_lock_acquire_shared, SRW_LOCK_HANDLE, handle);
+```
+
+`srw_lock_acquire_shared` acquires the SRWLOCK in shared (read) mode.
+
+**SRS_SRW_LOCK_02_017: [** If `handle` is `NULL` then `srw_lock_acquire_shared` shall return. **]**
+
+**SRS_SRW_LOCK_02_018: [** `srw_lock_acquire_shared` shall call `AcquireSRWLockShared`. **]**
+
+**SRS_SRW_LOCK_02_026: [** If `do_statistics` is `true` and the timer created has recorded more than `TIME_BETWEEN_STATISTICS_LOG` seconds then statistics will be logged and the timer shall be started again. **]**
+
+### srw_lock_try_acquire_shared
+```c
+MOCKABLE_FUNCTION(, SRW_LOCK_TRY_ACQUIRE_RESULT, srw_lock_try_acquire_shared, SRW_LOCK_HANDLE, handle);
+```
+
+`srw_lock_try_acquire_shared` attempts to acquire the SRWLOCK in shared (read) mode.
+
+**SRS_SRW_LOCK_01_001: [** If `handle` is `NULL` then `srw_lock_try_acquire_shared` shall fail and return `SRW_LOCK_TRY_ACQUIRE_INVALID_ARGS`. **]**
+
+**SRS_SRW_LOCK_01_002: [** Otherwise `srw_lock_try_acquire_shared` shall call `TryAcquireSRWLockShared`. **]**
+
+**SRS_SRW_LOCK_01_003: [** If `TryAcquireSRWLockShared` returns `FALSE`, `srw_lock_try_acquire_shared` shall return `SRW_LOCK_TRY_ACQUIRE_COULD_NOT_ACQUIRE`. **]**
+
+**SRS_SRW_LOCK_01_004: [** If `TryAcquireSRWLockShared` returns `TRUE`, `srw_lock_try_acquire_shared` shall return `SRW_LOCK_TRY_ACQUIRE_OK`. **]**
+
+**SRS_SRW_LOCK_01_005: [** If `do_statistics` is `true` and the timer created has recorded more than `TIME_BETWEEN_STATISTICS_LOG` seconds then statistics will be logged and the timer shall be started again. **]**
+
+
+### srw_lock_release_shared
+```c
+MOCKABLE_FUNCTION(, void, srw_lock_release_shared, SRW_LOCK_HANDLE, handle);
+```
+
+**SRS_SRW_LOCK_02_020: [** If `handle` is `NULL` then `srw_lock_release_shared` shall return. **]**
+
+**SRS_SRW_LOCK_02_021: [** `srw_lock_release_shared` shall call `ReleaseSRWLockShared`. **]**
+
+
+### srw_lock_destroy
+```c
+MOCKABLE_FUNCTION(, void, srw_lock_destroy, SRW_LOCK_HANDLE, handle);
+```
+
+`srw_lock_destroy` frees all used resources.
+
+**SRS_SRW_LOCK_02_011: [** If `handle` is `NULL` then `srw_lock_destroy` shall return. **]**
+
+**SRS_SRW_LOCK_02_012: [** `srw_lock_destroy` shall free all used resources. **]**
+

--- a/interfaces/inc/c_pal/srw_lock_ll.h
+++ b/interfaces/inc/c_pal/srw_lock_ll.h
@@ -1,7 +1,7 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 
-#ifndef SRW_LOCK_H
-#define SRW_LOCK_H
+#ifndef SRW_LOCK_LL_H
+#define SRW_LOCK_LL_H
 
 #ifdef __cplusplus
 #include <cstdbool>
@@ -9,38 +9,43 @@
 #include <stdbool.h>
 #endif
 
+#ifdef WIN32
+#include "windows.h"
+#endif // WINDOWS
+
 #include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c_prod.h"
 
 #ifdef __cplusplus
 extern "C" {
+#endif // __cplusplus
+
+#ifdef WIN32
+typedef SRWLOCK SRW_LOCK_LL;
 #endif
 
-typedef struct SRW_LOCK_HANDLE_DATA_TAG* SRW_LOCK_HANDLE;
+#define SRW_LOCK_LL_TRY_ACQUIRE_RESULT_VALUES \
+    SRW_LOCK_LL_TRY_ACQUIRE_OK, \
+    SRW_LOCK_LL_TRY_ACQUIRE_COULD_NOT_ACQUIRE, \
+    SRW_LOCK_LL_TRY_ACQUIRE_INVALID_ARGS
 
-#define SRW_LOCK_TRY_ACQUIRE_RESULT_VALUES \
-    SRW_LOCK_TRY_ACQUIRE_OK, \
-    SRW_LOCK_TRY_ACQUIRE_COULD_NOT_ACQUIRE, \
-    SRW_LOCK_TRY_ACQUIRE_INVALID_ARGS
+MU_DEFINE_ENUM(SRW_LOCK_LL_TRY_ACQUIRE_RESULT, SRW_LOCK_LL_TRY_ACQUIRE_RESULT_VALUES)
 
-MU_DEFINE_ENUM(SRW_LOCK_TRY_ACQUIRE_RESULT, SRW_LOCK_TRY_ACQUIRE_RESULT_VALUES)
-
-MOCKABLE_FUNCTION(, SRW_LOCK_HANDLE, srw_lock_create, bool, do_statistics, const char*, lock_name);
+MOCKABLE_FUNCTION(, int, srw_lock_ll_init, SRW_LOCK_LL*, srw_lock_ll);
+MOCKABLE_FUNCTION(, void, srw_lock_ll_deinit, SRW_LOCK_LL*, srw_lock_ll);
 
 /*writer APIs*/
-MOCKABLE_FUNCTION(, void, srw_lock_acquire_exclusive, SRW_LOCK_HANDLE, handle);
-MOCKABLE_FUNCTION(, SRW_LOCK_TRY_ACQUIRE_RESULT, srw_lock_try_acquire_exclusive, SRW_LOCK_HANDLE, handle);
-MOCKABLE_FUNCTION(, void, srw_lock_release_exclusive, SRW_LOCK_HANDLE, handle);
+MOCKABLE_FUNCTION(, void, srw_lock_ll_acquire_exclusive, SRW_LOCK_LL*, srw_lock_ll);
+MOCKABLE_FUNCTION(, SRW_LOCK_LL_TRY_ACQUIRE_RESULT, srw_lock_ll_try_acquire_exclusive, SRW_LOCK_LL*, srw_lock_ll);
+MOCKABLE_FUNCTION(, void, srw_lock_ll_release_exclusive, SRW_LOCK_LL*, srw_lock_ll);
 
 /*reader APIs*/
-MOCKABLE_FUNCTION(, void, srw_lock_acquire_shared, SRW_LOCK_HANDLE, handle);
-MOCKABLE_FUNCTION(, SRW_LOCK_TRY_ACQUIRE_RESULT, srw_lock_try_acquire_shared, SRW_LOCK_HANDLE, handle);
-MOCKABLE_FUNCTION(, void, srw_lock_release_shared, SRW_LOCK_HANDLE, handle);
-
-MOCKABLE_FUNCTION(, void, srw_lock_destroy, SRW_LOCK_HANDLE, handle);
+MOCKABLE_FUNCTION(, void, srw_lock_ll_acquire_shared, SRW_LOCK_LL*, srw_lock_ll);
+MOCKABLE_FUNCTION(, SRW_LOCK_LL_TRY_ACQUIRE_RESULT, srw_lock_ll_try_acquire_shared, SRW_LOCK_LL*, srw_lock_ll);
+MOCKABLE_FUNCTION(, void, srw_lock_ll_release_shared, SRW_LOCK_LL*, srw_lock_ll);
 
 #ifdef __cplusplus
 }
-#endif
+#endif // __cplusplus
 
-#endif
+#endif // SRW_LOCK_LL_H

--- a/interfaces/inc/c_pal/srw_lock_ll.h
+++ b/interfaces/inc/c_pal/srw_lock_ll.h
@@ -1,0 +1,46 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+#ifndef SRW_LOCK_H
+#define SRW_LOCK_H
+
+#ifdef __cplusplus
+#include <cstdbool>
+#else
+#include <stdbool.h>
+#endif
+
+#include "macro_utils/macro_utils.h"
+#include "umock_c/umock_c_prod.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct SRW_LOCK_HANDLE_DATA_TAG* SRW_LOCK_HANDLE;
+
+#define SRW_LOCK_TRY_ACQUIRE_RESULT_VALUES \
+    SRW_LOCK_TRY_ACQUIRE_OK, \
+    SRW_LOCK_TRY_ACQUIRE_COULD_NOT_ACQUIRE, \
+    SRW_LOCK_TRY_ACQUIRE_INVALID_ARGS
+
+MU_DEFINE_ENUM(SRW_LOCK_TRY_ACQUIRE_RESULT, SRW_LOCK_TRY_ACQUIRE_RESULT_VALUES)
+
+MOCKABLE_FUNCTION(, SRW_LOCK_HANDLE, srw_lock_create, bool, do_statistics, const char*, lock_name);
+
+/*writer APIs*/
+MOCKABLE_FUNCTION(, void, srw_lock_acquire_exclusive, SRW_LOCK_HANDLE, handle);
+MOCKABLE_FUNCTION(, SRW_LOCK_TRY_ACQUIRE_RESULT, srw_lock_try_acquire_exclusive, SRW_LOCK_HANDLE, handle);
+MOCKABLE_FUNCTION(, void, srw_lock_release_exclusive, SRW_LOCK_HANDLE, handle);
+
+/*reader APIs*/
+MOCKABLE_FUNCTION(, void, srw_lock_acquire_shared, SRW_LOCK_HANDLE, handle);
+MOCKABLE_FUNCTION(, SRW_LOCK_TRY_ACQUIRE_RESULT, srw_lock_try_acquire_shared, SRW_LOCK_HANDLE, handle);
+MOCKABLE_FUNCTION(, void, srw_lock_release_shared, SRW_LOCK_HANDLE, handle);
+
+MOCKABLE_FUNCTION(, void, srw_lock_destroy, SRW_LOCK_HANDLE, handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/win32/CMakeLists.txt
+++ b/win32/CMakeLists.txt
@@ -43,6 +43,7 @@ set(pal_win32_c_files
     src/pipe_win32.c
     src/platform_win32.c
     src/srw_lock_win32.c
+    src/srw_lock_ll_win32.c
     src/string_utils.c
     src/timer_win32.c
     src/sysinfo_win32.c

--- a/win32/devdoc/srw_lock_ll_win32_requirements.md
+++ b/win32/devdoc/srw_lock_ll_win32_requirements.md
@@ -1,8 +1,8 @@
-# `srw_lock_ll` requirements
+# `srw_lock_ll_win32` requirements
 
 ## Overview
 
-`srw_lock_ll` is the implementation of a slim reader writer lock.
+`srw_lock_ll_win32` is the implementation of a slim reader writer lock (`srw_lock_ll` interface). On Windows it simply wraps `SRWLOCK`.
 
 ## Exposed API
 
@@ -37,12 +37,20 @@ MOCKABLE_FUNCTION(, void, srw_lock_ll_init, SRW_LOCK_LL*, srw_lock_ll);
 
 `srw_lock_ll_init` initializes a slim reader writer lock.
 
+If `srw_lock_ll` is `NULL`, `srw_lock_ll_init` shall return.
+
+Otherwise, `srw_lock_ll_init` shall call `InitializeSRWLock`.
+
 ### srw_lock_ll_deinit
 ```c
 MOCKABLE_FUNCTION(, void, srw_lock_ll_deinit, SRW_LOCK_LL*, srw_lock_ll);
 ```
 
 `srw_lock_ll_deinit` frees deinitializes the slim reader writer lock.
+
+If `srw_lock_ll` is `NULL` then `srw_lock_ll_deinit` shall return.
+
+Otherwise, `srw_lock_ll_deinit` shall return.
 
 ### srw_lock_ll_acquire_exclusive
 ```c
@@ -51,6 +59,9 @@ MOCKABLE_FUNCTION(, void, srw_lock_ll_acquire_exclusive, SRW_LOCK_LL*, srw_lock_
 
 `srw_lock_ll_acquire_exclusive` acquires the slim reader writer lock in exclusive (writer) mode.
 
+If `srw_lock_ll` is `NULL` then `srw_lock_ll_acquire_exclusive` shall return.
+
+`srw_lock_ll_acquire_exclusive` shall call `AcquireSRWLockExclusive`.
 
 ### srw_lock_ll_try_acquire_exclusive
 ```c
@@ -59,12 +70,24 @@ MOCKABLE_FUNCTION(, SRW_LOCK_LL_TRY_ACQUIRE_RESULT, srw_lock_ll_try_acquire_excl
 
 `srw_lock_ll_try_acquire_exclusive` attempts to acquire the slim reader writer lock in exclusive (writer) mode.
 
+If `srw_lock_ll` is `NULL` then `srw_lock_ll_try_acquire_exclusive` shall fail and return `SRW_LOCK_TRY_ACQUIRE_INVALID_ARGS`.
+
+Otherwise `srw_lock_ll_try_acquire_exclusive` shall call `TryAcquireSRWLockExclusive`.
+
+If `TryAcquireSRWLockExclusive` returns `FALSE`, `srw_lock_ll_try_acquire_exclusive` shall return `SRW_LOCK_LL_TRY_ACQUIRE_COULD_NOT_ACQUIRE`.
+
+If `TryAcquireSRWLockExclusive` returns `TRUE`, `srw_lock_ll_try_acquire_exclusive` shall return `SRW_LOCK_LL_TRY_ACQUIRE_OK`.
+
 ### srw_lock_ll_release_exclusive
 ```c
 MOCKABLE_FUNCTION(, void, srw_lock_ll_release_exclusive, SRW_LOCK_LL*, srw_lock_ll);
 ```
 
 `srw_lock_ll_release_exclusive` releases the underlying slim reader writer lock from exclusive (write) mode.
+
+If `srw_lock_ll` is `NULL` then `srw_lock_ll_release_exclusive` shall return.
+
+`srw_lock_ll_release_exclusive` shall call `ReleaseSRWLockExclusive`.
 
 ### srw_lock_ll_acquire_shared
 ```c
@@ -73,6 +96,10 @@ MOCKABLE_FUNCTION(, void, srw_lock_ll_acquire_shared, SRW_LOCK_LL*, srw_lock_ll)
 
 `srw_lock_ll_acquire_shared` acquires the SRWLOCK in shared (read) mode.
 
+If `srw_lock_ll` is `NULL` then `srw_lock_ll_acquire_shared` shall return.
+
+`srw_lock_ll_acquire_shared` shall call `AcquireSRWLockShared`.
+
 ### srw_lock_ll_try_acquire_shared
 ```c
 MOCKABLE_FUNCTION(, SRW_LOCK_LL_TRY_ACQUIRE_RESULT, srw_lock_ll_try_acquire_shared, SRW_LOCK_LL*, srw_lock_ll);
@@ -80,9 +107,21 @@ MOCKABLE_FUNCTION(, SRW_LOCK_LL_TRY_ACQUIRE_RESULT, srw_lock_ll_try_acquire_shar
 
 `srw_lock_ll_try_acquire_shared` attempts to acquire the slim reader writer lock in shared (read) mode.
 
+If `srw_lock_ll` is `NULL` then `srw_lock_ll_try_acquire_shared` shall fail and return `SRW_LOCK_LL_TRY_ACQUIRE_INVALID_ARGS`.
+
+Otherwise `srw_lock_ll_try_acquire_shared` shall call `TryAcquireSRWLockShared`.
+
+If `TryAcquireSRWLockShared` returns `FALSE`, `srw_lock_ll_try_acquire_shared` shall return `SRW_LOCK_LL_TRY_ACQUIRE_COULD_NOT_ACQUIRE`.
+
+If `TryAcquireSRWLockShared` returns `TRUE`, `srw_lock_ll_try_acquire_shared` shall return `SRW_LOCK_LL_TRY_ACQUIRE_OK`.
+
 ### srw_lock_ll_release_shared
 ```c
 MOCKABLE_FUNCTION(, void, srw_lock_ll_release_shared, SRW_LOCK_LL*, srw_lock_ll);
 ```
 
 `srw_lock_ll_release_shared` releases the underlying slim reader writer lock from shared (read) mode.
+
+If `srw_lock_ll` is `NULL` then `srw_lock_ll_release_shared` shall return.
+
+`srw_lock_ll_release_shared` shall call `ReleaseSRWLockShared`.

--- a/win32/devdoc/srw_lock_ll_win32_requirements.md
+++ b/win32/devdoc/srw_lock_ll_win32_requirements.md
@@ -4,7 +4,17 @@
 
 `srw_lock_ll_win32` is the implementation of a slim reader writer lock (`srw_lock_ll` interface). On Windows it simply wraps `SRWLOCK`.
 
+References:
+
+[https://learn.microsoft.com/en-us/windows/win32/sync/slim-reader-writer--srw--locks](https://learn.microsoft.com/en-us/windows/win32/sync/slim-reader-writer--srw--locks)
+
 ## Exposed API
+
+For Windows the type `SRW_LOCK_LL` is defined to be `SRWLOCK`.
+
+```c
+typedef SRWLOCK SRW_LOCK_LL;
+```
 
 ```c
 #define SRW_LOCK_LL_TRY_ACQUIRE_RESULT_VALUES \
@@ -12,11 +22,9 @@
     SRW_LOCK_LL_TRY_ACQUIRE_COULD_NOT_ACQUIRE, \
     SRW_LOCK_LL_TRY_ACQUIRE_INVALID_ARGS
 
-typedef void* SRW_LOCK_LL;
-
 MU_DEFINE_ENUM(SRW_LOCK_LL_TRY_ACQUIRE_RESULT, SRW_LOCK_LL_TRY_ACQUIRE_RESULT_VALUES)
 
-MOCKABLE_FUNCTION(, void, srw_lock_ll_init);
+MOCKABLE_FUNCTION(, void, srw_lock_ll_init, SRW_LOCK_LL*, srw_lock_ll);
 MOCKABLE_FUNCTION(, void, srw_lock_ll_deinit, SRW_LOCK_LL*, srw_lock_ll);
 
 /*writer APIs*/
@@ -37,16 +45,18 @@ MOCKABLE_FUNCTION(, void, srw_lock_ll_init, SRW_LOCK_LL*, srw_lock_ll);
 
 `srw_lock_ll_init` initializes a slim reader writer lock.
 
-If `srw_lock_ll` is `NULL`, `srw_lock_ll_init` shall return.
+If `srw_lock_ll` is `NULL`, `srw_lock_ll_init` shall fail and return a non-zero value.
 
 Otherwise, `srw_lock_ll_init` shall call `InitializeSRWLock`.
+
+`srw_lock_ll_init` shall succeed and return 0.
 
 ### srw_lock_ll_deinit
 ```c
 MOCKABLE_FUNCTION(, void, srw_lock_ll_deinit, SRW_LOCK_LL*, srw_lock_ll);
 ```
 
-`srw_lock_ll_deinit` frees deinitializes the slim reader writer lock.
+`srw_lock_ll_deinit` deinitializes the slim reader writer lock.
 
 If `srw_lock_ll` is `NULL` then `srw_lock_ll_deinit` shall return.
 
@@ -94,7 +104,7 @@ If `srw_lock_ll` is `NULL` then `srw_lock_ll_release_exclusive` shall return.
 MOCKABLE_FUNCTION(, void, srw_lock_ll_acquire_shared, SRW_LOCK_LL*, srw_lock_ll);
 ```
 
-`srw_lock_ll_acquire_shared` acquires the SRWLOCK in shared (read) mode.
+`srw_lock_ll_acquire_shared` acquires the slim reader writer lock in shared (read) mode.
 
 If `srw_lock_ll` is `NULL` then `srw_lock_ll_acquire_shared` shall return.
 

--- a/win32/src/srw_lock_ll_win32.c
+++ b/win32/src/srw_lock_ll_win32.c
@@ -1,3 +1,46 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 
+#include "macro_utils/macro_utils.h"
+
 #include "c_pal/srw_lock_ll.h"
+
+int srw_lock_ll_init(SRW_LOCK_LL* srw_lock_ll)
+{
+    (void)srw_lock_ll;
+    return MU_FAILURE;
+}
+
+void srw_lock_ll_deinit(SRW_LOCK_LL* srw_lock_ll)
+{
+    (void)srw_lock_ll;
+}
+
+void srw_lock_ll_acquire_exclusive(SRW_LOCK_LL* srw_lock_ll)
+{
+    (void)srw_lock_ll;
+}
+
+SRW_LOCK_LL_TRY_ACQUIRE_RESULT srw_lock_ll_try_acquire_exclusive(SRW_LOCK_LL* srw_lock_ll)
+{
+    (void)srw_lock_ll;
+}
+
+void srw_lock_ll_release_exclusive(SRW_LOCK_LL* srw_lock_ll)
+{
+    (void)srw_lock_ll;
+}
+
+void srw_lock_ll_acquire_shared(SRW_LOCK_LL* srw_lock_ll)
+{
+    (void)srw_lock_ll;
+}
+
+SRW_LOCK_LL_TRY_ACQUIRE_RESULT srw_lock_ll_try_acquire_shared(SRW_LOCK_LL* srw_lock_ll)
+{
+    (void)srw_lock_ll;
+}
+
+void srw_lock_ll_release_shared(SRW_LOCK_LL* srw_lock_ll)
+{
+    (void)srw_lock_ll;
+}

--- a/win32/src/srw_lock_ll_win32.c
+++ b/win32/src/srw_lock_ll_win32.c
@@ -1,0 +1,3 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+#include "c_pal/srw_lock_ll.h"


### PR DESCRIPTION
We need to split the current srw_lock in 2 layers, thus creating a srw_lock_ll which should be a simple wrapper of a lock, without any memory allocation.