### PR TITLE
adding header and spec for sm handling opening complete

### DIFF
--- a/common/devdoc/sm_requirements.md
+++ b/common/devdoc/sm_requirements.md
@@ -399,6 +399,12 @@ If `sm` is `NULL` then `sm_on_error` shall return.
 
 If `on_error_callback` is `NULL` then `sm_on_error` shall return.
 
+If `state` is not `SM_OPENED` and not `SM_OPENING` then `sm_on_error` shall return
+
+If `SM_CLOSE_BIT` is 1 then `sm_on_error` shall return.
+
+If `SM_FAULTED_BIT` is 1 then `sm_on_error` shall return
+
 `sm_on_error` shall increment the non_barrier_call_count.
 
 `sm_on_error` shall set `SM_FAULTED_BIT` to 1.

--- a/common/devdoc/sm_requirements.md
+++ b/common/devdoc/sm_requirements.md
@@ -182,6 +182,8 @@ MOCKABLE_FUNCTION(, void, sm_open_end, SM_HANDLE, sm, bool, success);
 
 **SRS_SM_02_041: [** If state is not `SM_OPENING` then `sm_open_end` shall return. **]**
 
+If `SM_FAULTED_BIT` is 1 then `sm_open_end` shall return.
+
 **SRS_SM_02_074: [** If `success` is `true` then `sm_open_end` shall switch the state to `SM_OPENED`. **]**
 
 **SRS_SM_02_075: [** If `success` is `false` then `sm_open_end` shall switch the state to `SM_CREATED`. **]**
@@ -192,7 +194,7 @@ MOCKABLE_FUNCTION(, void, sm_open_end, SM_HANDLE, sm, bool, success);
 MOCKABLE_FUNCTION(, SM_RESULT, sm_on_open_complete, SM_HANDLE, sm);
 ```
 
-`sm_on_open_complete` informs the user's that calling on_open_complete is allowed.
+`sm_on_open_complete` informs the user that calling on_open_complete is allowed.
 
 If `sm` is `NULL` then `sm_on_open_complete` shall fail and return `SM_ERROR`.
 
@@ -391,12 +393,16 @@ MOCKABLE_FUNCTION(, void, sm_fault, SM_HANDLE, sm);
 MOCKABLE_FUNCTION(, void, sm_on_error, SM_HANDLE, sm, ON_ERROR_CALLBACK, on_error_callback, void*, on_error_ctx);
 ```
 
-`sm_on_error` informs the user's that the call to sm_on_error is done in the opening state.
+`sm_on_error` informs the user that the call to sm_on_error is done in the opening state.
 
 If `sm` is `NULL` then `sm_on_error` shall return.
 
 If `on_error_callback` is `NULL` then `sm_on_error` shall return.
 
+`sm_on_error` shall increment the non_barrier_call_count.
+
 `sm_on_error` shall set `SM_FAULTED_BIT` to 1.
 
-`sm_on_error` shall call the `on_error_callback`
+`sm_on_error` shall call the `on_error_callback` with whether it is in the opening state.
+
+`sm_on_error` shall decrement the non_barrier_call_count.

--- a/common/inc/c_pal/sm.h
+++ b/common/inc/c_pal/sm.h
@@ -30,12 +30,14 @@ MU_DEFINE_ENUM(SM_RESULT, SM_RESULT_VALUES);
 
 typedef void(*ON_SM_CLOSING_COMPLETE_CALLBACK)(void* context);
 typedef void(*ON_SM_CLOSING_WHILE_OPENING_CALLBACK)(void* context);
+typedef void(*ON_ERROR_CALLBACK)(void* context, bool is_opening);
 
 MOCKABLE_FUNCTION(, SM_HANDLE, sm_create, const char*, name);
 MOCKABLE_FUNCTION(, void, sm_destroy, SM_HANDLE, sm);
 
 MOCKABLE_FUNCTION(, SM_RESULT, sm_open_begin, SM_HANDLE, sm);
 MOCKABLE_FUNCTION(, void, sm_open_end, SM_HANDLE, sm, bool, success);
+MOCKABLE_FUNCTION(, SM_RESULT, sm_on_open_complete, SM_HANDLE, sm);
 
 MOCKABLE_FUNCTION(, SM_RESULT, sm_close_begin, SM_HANDLE, sm);
 MOCKABLE_FUNCTION(, SM_RESULT, sm_close_begin_with_cb, SM_HANDLE, sm, ON_SM_CLOSING_COMPLETE_CALLBACK, callback, void*, callback_context, ON_SM_CLOSING_WHILE_OPENING_CALLBACK, close_while_opening_callback, void*, close_while_opening_context);
@@ -48,6 +50,7 @@ MOCKABLE_FUNCTION(, SM_RESULT, sm_barrier_begin, SM_HANDLE, sm);
 MOCKABLE_FUNCTION(, void, sm_barrier_end, SM_HANDLE, sm);
 
 MOCKABLE_FUNCTION(, void, sm_fault, SM_HANDLE, sm);
+MOCKABLE_FUNCTION(, void, sm_on_error, SM_HANDLE, sm, ON_ERROR_CALLBACK, on_error_callback, void*, on_error_ctx);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Adding spec to sm to enable the handling of open_complete callback during the opening state.