### PR TITLE
Add srw lock low-level Linux implementation

### DIFF
--- a/linux/linux_reals/CMakeLists.txt
+++ b/linux/linux_reals/CMakeLists.txt
@@ -9,6 +9,7 @@ set(linux_reals_c_files
     real_pipe.c
     real_string_utils_linux.c
     real_srw_lock.c
+    real_srw_lock_ll_linux.c
     real_threadpool.c
     real_timer.c
     real_uuid.c

--- a/linux/linux_reals/real_srw_lock_ll_linux.c
+++ b/linux/linux_reals/real_srw_lock_ll_linux.c
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "real_srw_lock_ll_renames.h" // IWYU pragma: keep
+
+#include "../src/srw_lock_ll_linux.c"


### PR DESCRIPTION
This is needed to make things link when building on Linux with the `TCALL_DISPATCHER` functions from `c-util` repo.