### PR TITLE
Use real_interlocked in real_threadpool

### DIFF
--- a/win32/reals/real_threadpool.c
+++ b/win32/reals/real_threadpool.c
@@ -3,6 +3,8 @@
 
 #include "real_gballoc_hl_renames.h"
 
+#include "real_interlocked_renames.h"
+
 #include "real_execution_engine_renames.h"
 
 #include "real_execution_engine_win32_renames.h"


### PR DESCRIPTION
If a test is mocking `interlocked.h` and using `real_threadpool.h`, `THANDLE` functions cause `interlocked` calls to get recorded.
 