### PR TITLE
Add a macro for volatile int32_t plus enum union

### DIFF
--- a/c_pal_ll/interfaces/CMakeLists.txt
+++ b/c_pal_ll/interfaces/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 set(pal_ll_interfaces_h_files
     inc/c_pal/interlocked.h
+    inc/c_pal/interlocked_macros.h
     inc/c_pal/sync.h
     inc/c_pal/threadapi.h
 )

--- a/c_pal_ll/interfaces/devdoc/interlocked_macros_requirements.md
+++ b/c_pal_ll/interfaces/devdoc/interlocked_macros_requirements.md
@@ -1,0 +1,39 @@
+# interlocked macros
+
+## Overview
+
+`interlocked_macros` contains macros related to interlocked variables.
+
+Currently there is only one such macro, described below.
+
+## Exposed API
+
+```c
+#define INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM(enum_type, variable_name) \
+    union \
+    { \
+        volatile_atomic int32_t variable_name; \
+        enum_type MU_C2(variable_name, _enum); \
+    };
+```
+
+## INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM
+
+```c
+#define INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM(enum_type, variable_name)
+```
+
+This generates a field like :
+
+```c
+    union
+    {
+        volatile_atomic int32_t variable_name;
+        MY_STATE_ENUM variable_name_enum;
+    };
+```
+
+This is useful for fields which need to be volatile for interlocked operations but are actually an enum (such as a state variable).
+The `variable_name_enum` field can be viewed in the debugger to see the value as an enum.
+
+**SRS_INTERLOCKED_MACROS_42_001: [** `INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM` shall generate a union with two fields: a `volatile_atomic` `int32_t` and a variable of the type `enum_type`. **]**

--- a/c_pal_ll/interfaces/devdoc/interlocked_macros_requirements.md
+++ b/c_pal_ll/interfaces/devdoc/interlocked_macros_requirements.md
@@ -36,4 +36,6 @@ This generates a field like :
 This is useful for fields which need to be volatile for interlocked operations but are actually an enum (such as a state variable).
 The `variable_name_enum` field can be viewed in the debugger to see the value as an enum.
 
+Note that the enum type must be of the same size as `int32_t`.
+
 **SRS_INTERLOCKED_MACROS_42_001: [** `INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM` shall generate a union with two fields: a `volatile_atomic` `int32_t` and a variable of the type `enum_type`. **]**

--- a/c_pal_ll/interfaces/inc/c_pal/interlocked.h
+++ b/c_pal_ll/interfaces/inc/c_pal/interlocked.h
@@ -14,6 +14,8 @@
 
 #include "umock_c/umock_c_prod.h"
 
+#include "interlocked_macros.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/c_pal_ll/interfaces/inc/c_pal/interlocked_macros.h
+++ b/c_pal_ll/interfaces/inc/c_pal/interlocked_macros.h
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef INTERLOCKED_MACROS_H
+#define INTERLOCKED_MACROS_H
+
+#ifdef __cplusplus
+#include <cstdint>
+
+#else
+#include <stdint.h>
+#endif
+
+#include "macro_utils/macro_utils.h"
+
+#include "c_pal/interlocked.h"
+
+/*Codes_SRS_INTERLOCKED_MACROS_42_001: [ INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM shall generate a union with two fields: a volatile_atomic int32_t and a variable of the type enum_type. ]*/
+#define INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM(enum_type, variable_name) \
+    union \
+    { \
+        volatile_atomic int32_t variable_name; \
+        enum_type MU_C2(variable_name, _enum); \
+    }
+
+#endif // INTERLOCKED_MACROS_H

--- a/c_pal_ll/interfaces/inc/c_pal/interlocked_macros.h
+++ b/c_pal_ll/interfaces/inc/c_pal/interlocked_macros.h
@@ -13,14 +13,13 @@
 
 #include "macro_utils/macro_utils.h"
 
-#include "c_pal/interlocked.h"
-
 /*Codes_SRS_INTERLOCKED_MACROS_42_001: [ INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM shall generate a union with two fields: a volatile_atomic int32_t and a variable of the type enum_type. ]*/
 #define INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM(enum_type, variable_name) \
     union \
     { \
         volatile_atomic int32_t variable_name; \
         enum_type MU_C2(variable_name, _enum); \
+        char MU_C3(assert_that_, enum_type, _is_int32_t_size)[(sizeof(int32_t)==sizeof(enum_type)) ? 1 : -1];\
     }
 
 #endif // INTERLOCKED_MACROS_H

--- a/c_pal_ll/interfaces/tests/CMakeLists.txt
+++ b/c_pal_ll/interfaces/tests/CMakeLists.txt
@@ -1,5 +1,9 @@
 #Copyright (C) Microsoft Corporation. All rights reserved.
 
+if(${run_unittests})
+    build_test_folder(interlocked_macros_ut)
+endif()
+
 if(${run_int_tests})
     build_test_folder(interlocked_int)
     build_test_folder(sync_int)

--- a/c_pal_ll/interfaces/tests/interlocked_macros_ut/CMakeLists.txt
+++ b/c_pal_ll/interfaces/tests/interlocked_macros_ut/CMakeLists.txt
@@ -1,0 +1,14 @@
+#Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+set(theseTestsName interlocked_macros_ut)
+
+set(${theseTestsName}_test_files
+    ${theseTestsName}.c
+)
+
+set(${theseTestsName}_h_files
+    ../../inc/c_pal/interlocked_macros.h
+)
+
+build_test_artifacts(${theseTestsName} "tests/c_pal_ll/int" ADDITIONAL_LIBS c_pal)

--- a/c_pal_ll/interfaces/tests/interlocked_macros_ut/interlocked_macros_ut.c
+++ b/c_pal_ll/interfaces/tests/interlocked_macros_ut/interlocked_macros_ut.c
@@ -1,0 +1,61 @@
+//Copyright(c) Microsoft.All rights reserved.
+//Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "testrunnerswitcher.h"
+
+#include "macro_utils/macro_utils.h"
+
+#include "c_pal/interlocked.h"
+#include "c_pal/interlocked_macros.h"
+
+BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
+
+TEST_SUITE_INITIALIZE(a)
+{
+}
+
+TEST_SUITE_CLEANUP(b)
+{
+}
+
+TEST_FUNCTION_INITIALIZE(c)
+{
+}
+
+TEST_FUNCTION_CLEANUP(d)
+{
+}
+
+#define MY_ENUM_VALUES \
+    MY_ENUM_VALUE_1, \
+    MY_ENUM_VALUE_2, \
+    MY_ENUM_VALUE_3
+MU_DEFINE_ENUM(MY_ENUM, MY_ENUM_VALUES);
+
+typedef struct TEST_STRUCT_TAG
+{
+    INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM(MY_ENUM, state);
+} TEST_STRUCT;
+
+// Mostly a case of "if it compiles..."
+/*Tests_SRS_INTERLOCKED_MACROS_42_001: [ INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM shall generate a union with two fields: a volatile_atomic int32_t and a variable of the type enum_type. ]*/
+TEST_FUNCTION(INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM_works_with_some_enum)
+{
+    ///arrange
+    TEST_STRUCT test_struct;
+
+    ///act
+    test_struct.state_enum = MY_ENUM_VALUE_1;
+    (void)interlocked_exchange(&test_struct.state, MY_ENUM_VALUE_2);
+
+    ///assert
+    size_t size_of_int32_t = sizeof(int32_t);
+    size_t size_of_enum = sizeof(MY_ENUM);
+    size_t expected_size = max(size_of_int32_t, size_of_enum);
+    ASSERT_ARE_EQUAL(size_t, expected_size, sizeof(test_struct));
+}
+
+END_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)

--- a/c_pal_ll/interfaces/tests/interlocked_macros_ut/interlocked_macros_ut.c
+++ b/c_pal_ll/interfaces/tests/interlocked_macros_ut/interlocked_macros_ut.c
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #include "testrunnerswitcher.h"
 

--- a/c_pal_ll/interfaces/tests/interlocked_macros_ut/interlocked_macros_ut.c
+++ b/c_pal_ll/interfaces/tests/interlocked_macros_ut/interlocked_macros_ut.c
@@ -6,7 +6,7 @@
 
 #include "testrunnerswitcher.h"
 
-#include "macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h" // IWYU pragma: keep
 
 #include "c_pal/interlocked.h"
 #include "c_pal/interlocked_macros.h"

--- a/c_pal_ll/interfaces/tests/interlocked_macros_ut/interlocked_macros_ut.c
+++ b/c_pal_ll/interfaces/tests/interlocked_macros_ut/interlocked_macros_ut.c
@@ -9,7 +9,6 @@
 #include "macro_utils/macro_utils.h" // IWYU pragma: keep
 
 #include "c_pal/interlocked.h"
-#include "c_pal/interlocked_macros.h"
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 

--- a/c_pal_ll/interfaces/tests/interlocked_macros_ut/interlocked_macros_ut.c
+++ b/c_pal_ll/interfaces/tests/interlocked_macros_ut/interlocked_macros_ut.c
@@ -3,7 +3,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <stdlib.h>
 
 #include "testrunnerswitcher.h"
 
@@ -57,7 +56,7 @@ TEST_FUNCTION(INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM_works_with_some_enum)
     ///assert
     size_t size_of_int32_t = sizeof(int32_t);
     size_t size_of_enum = sizeof(MY_ENUM);
-    size_t expected_size = max(size_of_int32_t, size_of_enum);
+    size_t expected_size = (size_of_int32_t > size_of_enum ? size_of_int32_t : size_of_enum);
     ASSERT_ARE_EQUAL(size_t, expected_size, sizeof(test_struct));
     ASSERT_ARE_EQUAL(uint32_t, MY_ENUM_VALUE_2, interlocked_add(&test_struct.state, 0));
     ASSERT_ARE_EQUAL(MY_ENUM, MY_ENUM_VALUE_2, test_struct.state_enum);

--- a/c_pal_ll/interfaces/tests/interlocked_macros_ut/interlocked_macros_ut.c
+++ b/c_pal_ll/interfaces/tests/interlocked_macros_ut/interlocked_macros_ut.c
@@ -42,6 +42,10 @@ typedef struct TEST_STRUCT_TAG
     INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM(MY_ENUM, state);
 } TEST_STRUCT;
 
+// Union by itself (outside of a struct) is also possible
+// We will use this to validate that we generate something with sizeof(uint32_t)
+INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM(MY_ENUM, state) MY_UNION;
+
 // Mostly a case of "if it compiles..."
 /*Tests_SRS_INTERLOCKED_MACROS_42_001: [ INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM shall generate a union with two fields: a volatile_atomic int32_t and a variable of the type enum_type. ]*/
 TEST_FUNCTION(INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM_works_with_some_enum)
@@ -54,11 +58,8 @@ TEST_FUNCTION(INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM_works_with_some_enum)
     (void)interlocked_exchange(&test_struct.state, MY_ENUM_VALUE_2);
 
     ///assert
-    size_t size_of_int32_t = sizeof(int32_t);
-    size_t size_of_enum = sizeof(MY_ENUM);
-    size_t expected_size = (size_of_int32_t > size_of_enum ? size_of_int32_t : size_of_enum);
-    ASSERT_ARE_EQUAL(size_t, expected_size, sizeof(test_struct));
-    ASSERT_ARE_EQUAL(uint32_t, MY_ENUM_VALUE_2, interlocked_add(&test_struct.state, 0));
+    ASSERT_ARE_EQUAL(size_t, sizeof(int32_t), sizeof(MY_UNION));
+    ASSERT_ARE_EQUAL(int32_t, MY_ENUM_VALUE_2, interlocked_add(&test_struct.state, 0));
     ASSERT_ARE_EQUAL(MY_ENUM, MY_ENUM_VALUE_2, test_struct.state_enum);
 }
 

--- a/c_pal_ll/interfaces/tests/interlocked_macros_ut/interlocked_macros_ut.c
+++ b/c_pal_ll/interfaces/tests/interlocked_macros_ut/interlocked_macros_ut.c
@@ -35,6 +35,8 @@ TEST_FUNCTION_CLEANUP(d)
     MY_ENUM_VALUE_3
 MU_DEFINE_ENUM(MY_ENUM, MY_ENUM_VALUES);
 
+TEST_DEFINE_ENUM_TYPE(MY_ENUM, MY_ENUM_VALUES);
+
 typedef struct TEST_STRUCT_TAG
 {
     INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM(MY_ENUM, state);
@@ -56,6 +58,8 @@ TEST_FUNCTION(INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM_works_with_some_enum)
     size_t size_of_enum = sizeof(MY_ENUM);
     size_t expected_size = max(size_of_int32_t, size_of_enum);
     ASSERT_ARE_EQUAL(size_t, expected_size, sizeof(test_struct));
+    ASSERT_ARE_EQUAL(uint32_t, MY_ENUM_VALUE_2, interlocked_add(&test_struct.state, 0));
+    ASSERT_ARE_EQUAL(MY_ENUM, MY_ENUM_VALUE_2, test_struct.state_enum);
 }
 
 END_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)


### PR DESCRIPTION
One-liner for:

```c
    union \
    { \
        volatile_atomic int32_t variable_name; \
        enum_type MU_C2(variable_name, _enum); \
    };
```

Where variable_name is used with interlocked functions and variable_name_enum is used for nicer debugging.