### PR TITLE
Add a guard around the work function in timer callback.

### DIFF
--- a/linux/devdoc/threadpool_linux_requirements.md
+++ b/linux/devdoc/threadpool_linux_requirements.md
@@ -317,6 +317,8 @@ MOCKABLE_FUNCTION(, void, threadpool_timer_destroy, TIMER_INSTANCE_HANDLE, timer
 
 **SRS_THREADPOOL_LINUX_07_071: [** `threadpool_timer_cancel` shall call `timer_delete` to destroy the ongoing timers. **]**
 
+**SRS_THREADPOOL_LINUX_45_012: [** `threadpool_timer_cancel` shall call `ThreadAPI_Sleep` to allow timer resources to clean up. **]**
+
 **SRS_THREADPOOL_LINUX_07_072: [** `threadpool_timer_destroy` shall free all resources in `timer`. **]**
 
 ### static void on_timer_callback(sigval_t timer_data);

--- a/linux/src/threadpool_linux.c
+++ b/linux/src/threadpool_linux.c
@@ -757,6 +757,7 @@ void threadpool_timer_destroy(TIMER_INSTANCE_HANDLE timer)
         {
             // Do Nothing
         }
+        /* Codes_SRS_THREADPOOL_LINUX_45_012: [ threadpool_timer_cancel shall call ThreadAPI_Sleep to allow timer resources to clean up. ]*/
         ThreadAPI_Sleep(10);
         /* Codes_SRS_THREADPOOL_LINUX_07_072: [ threadpool_timer_destroy shall free all resources in timer. ]*/
         free(timer);

--- a/linux/src/threadpool_linux.c
+++ b/linux/src/threadpool_linux.c
@@ -61,7 +61,7 @@ typedef struct TIMER_INSTANCE_TAG
     THREADPOOL_WORK_FUNCTION work_function;
     void* work_function_ctx;
     timer_t time_id;
-    INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM(TIMER_GUARD, work_guard);
+    INTERLOCKED_DEFINE_VOLATILE_STATE_ENUM(TIMER_GUARD, timer_work_guard);
 } TIMER_INSTANCE;
 
 typedef struct THREADPOOL_TASK_TAG
@@ -97,6 +97,8 @@ THANDLE_TYPE_DEFINE(THREADPOOL);
 
 static void on_timer_callback(sigval_t timer_data)
 {
+    /* Codes_SRS_THREADPOOL_LINUX_45_002: [ on_timer_callback shall set the timer instance to timer_data.sival_ptr. ]*/
+    /* Codes_SRS_THREADPOOL_LINUX_45_001: [ If timer instance is NULL, then on_timer_callback shall return. ]*/
     TIMER_INSTANCE* timer_instance = timer_data.sival_ptr;
     if (timer_instance == NULL)
     {
@@ -104,12 +106,16 @@ static void on_timer_callback(sigval_t timer_data)
     }
     else
     {
-        if (interlocked_compare_exchange(&timer_instance->work_guard, TIMER_WORKING, OK_TO_WORK) == OK_TO_WORK)
+        /* Codes_SRS_THREADPOOL_LINUX_45_003: [ on_timer_callback shall call interlocked_compare_exchange with the timer_work_guard of this timer instance with OK_TO_WORK as the comparison, and TIMER_WORKING as the exchange. ]*/
+        if (interlocked_compare_exchange(&timer_instance->timer_work_guard, TIMER_WORKING, OK_TO_WORK) == OK_TO_WORK)
         {
+            /* Codes_SRS_THREADPOOL_LINUX_45_004: [ If timer_work_guard is successfully set to TIMER_WORKING, then on_timer_callback shall call the timer's work_function with work_function_ctx. ]*/
             timer_instance->work_function(timer_instance->work_function_ctx);
-            if (interlocked_compare_exchange(&timer_instance->work_guard, OK_TO_WORK, TIMER_WORKING) == TIMER_WORKING)
+            /* Codes_SRS_THREADPOOL_LINUX_45_005: [ on_timer_callback shall call interlocked_compare_exchange with the timer_work_guard of this timer instance with TIMER_WORKING as the comparison, and OK_TO_WORK as the exchange. ]*/
+            if (interlocked_compare_exchange(&timer_instance->timer_work_guard, OK_TO_WORK, TIMER_WORKING) == TIMER_WORKING)
             {
-                wake_by_address_single(&timer_instance->work_guard);
+                /* Codes_SRS_THREADPOOL_LINUX_45_006: [ If timer_work_guard is successfully set to OK_TO_WORK, then then on_timer_callback shall call wake_by_address_single on timer_work_guard. ]*/
+                wake_by_address_single(&timer_instance->timer_work_guard);
             }
         }
     }
@@ -608,7 +614,8 @@ int threadpool_timer_start(THANDLE(THREADPOOL) threadpool, uint32_t start_delay_
             timer_instance->work_function = work_function;
             /* Codes_SRS_THREADPOOL_LINUX_07_057: [ work_function_ctx shall be allowed to be NULL. ]*/
             timer_instance->work_function_ctx = work_function_ctx;
-            (void)interlocked_exchange(&timer_instance->work_guard, OK_TO_WORK);
+            /* Codes_SRS_THREADPOOL_LINUX_45_011: [ threadpool_timer_start shall call interlocked_exchange to set the timer_work_guard to OK_TO_WORK. ]*/
+            (void)interlocked_exchange(&timer_instance->timer_work_guard, OK_TO_WORK);
             struct sigevent sigev = {0};
             timer_t time_id = 0;
 
@@ -724,14 +731,18 @@ void threadpool_timer_destroy(TIMER_INSTANCE_HANDLE timer)
     {
         while (true)
         {
-            INTERLOCKED_HL_RESULT guard_result = InterlockedHL_WaitForNotValue(&timer->work_guard, TIMER_WORKING, UINT32_MAX);
+            /* Codes_SRS_THREADPOOL_LINUX_45_008: [ threadpool_timer_destroy shall call InterlockedHL_WaitForNotValue to wait until timer_work_guard is not TIMER_WORKING. ]*/
+            INTERLOCKED_HL_RESULT guard_result = InterlockedHL_WaitForNotValue(&timer->timer_work_guard, TIMER_WORKING, UINT32_MAX);
             if (guard_result == INTERLOCKED_HL_OK)
             {
-                TIMER_GUARD guard_value = interlocked_add(&timer->work_guard, 0);
+                /* Codes_SRS_THREADPOOL_LINUX_45_009: [ threadpool_timer_destroy shall call interlocked_add to add 0 to timer_work_guard to get current value of timer_work_guard. ]*/
+                TIMER_GUARD guard_value = interlocked_add(&timer->timer_work_guard, 0);
                 if (guard_value != TIMER_WORKING)
                 {
-                    if (interlocked_compare_exchange(&timer->work_guard, TIMER_DELETING, guard_value) == guard_value)
+                    /* Codes_SRS_THREADPOOL_LINUX_45_010: [ threadpool_timer_destroy shall call interlocked_compare_exchange on timer_work_guard with the current value of timer_work_guard as the comparison and TIMER_DELETING as the exchange. ]*/
+                    if (interlocked_compare_exchange(&timer->timer_work_guard, TIMER_DELETING, guard_value) == guard_value)
                     {
+                        /* Codes_SRS_THREADPOOL_LINUX_45_007: [ Until timer_work_guard can be set to TIMER_DELETING. ]*/
                         break;
                     }
                 }

--- a/linux/src/threadpool_linux.c
+++ b/linux/src/threadpool_linux.c
@@ -757,6 +757,9 @@ void threadpool_timer_destroy(TIMER_INSTANCE_HANDLE timer)
         {
             // Do Nothing
         }
+        // Even though timer_delete does cancel any events, there is a small window where an event was triggered just before and a thread is being created.
+        // So the callback can still execute after the timer_delete call. A small wait here keeps the timer instance alive long enough for
+        // the callback to use it if we hit this window.
         /* Codes_SRS_THREADPOOL_LINUX_45_012: [ threadpool_timer_cancel shall call ThreadAPI_Sleep to allow timer resources to clean up. ]*/
         ThreadAPI_Sleep(10);
         /* Codes_SRS_THREADPOOL_LINUX_07_072: [ threadpool_timer_destroy shall free all resources in timer. ]*/

--- a/linux/src/threadpool_linux.c
+++ b/linux/src/threadpool_linux.c
@@ -608,7 +608,7 @@ int threadpool_timer_start(THANDLE(THREADPOOL) threadpool, uint32_t start_delay_
             timer_instance->work_function = work_function;
             /* Codes_SRS_THREADPOOL_LINUX_07_057: [ work_function_ctx shall be allowed to be NULL. ]*/
             timer_instance->work_function_ctx = work_function_ctx;
-
+            (void)interlocked_exchange(&timer_instance->work_guard, OK_TO_WORK);
             struct sigevent sigev = {0};
             timer_t time_id = 0;
 
@@ -746,7 +746,7 @@ void threadpool_timer_destroy(TIMER_INSTANCE_HANDLE timer)
         {
             // Do Nothing
         }
-        ThreadAPI_Sleep(20);
+        ThreadAPI_Sleep(10);
         /* Codes_SRS_THREADPOOL_LINUX_07_072: [ threadpool_timer_destroy shall free all resources in timer. ]*/
         free(timer);
     }

--- a/linux/tests/threadpool_linux_ut/threadpool_linux_ut.c
+++ b/linux/tests/threadpool_linux_ut/threadpool_linux_ut.c
@@ -1285,6 +1285,7 @@ TEST_FUNCTION(threadpool_timer_destroy_succeeds)
 /* Tests_SRS_THREADPOOL_LINUX_45_003: [ on_timer_callback shall call interlocked_compare_exchange with the timer_work_guard of this timer instance with OK_TO_WORK as the comparison, and TIMER_WORKING as the exchange. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_45_004: [ If timer_work_guard is successfully set to TIMER_WORKING, then on_timer_callback shall call the timer's work_function with work_function_ctx. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_45_005: [ on_timer_callback shall call interlocked_compare_exchange with the timer_work_guard of this timer instance with TIMER_WORKING as the comparison, and OK_TO_WORK as the exchange. ]*/
+/* Tests_SRS_THREADPOOL_LINUX_45_006: [ If timer_work_guard is successfully set to OK_TO_WORK, then then on_timer_callback shall call wake_by_address_single on timer_work_guard. ]*/
 TEST_FUNCTION(on_timer_callback_calls_work_function)
 {
     // arrange
@@ -1304,7 +1305,7 @@ TEST_FUNCTION(on_timer_callback_calls_work_function)
     STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(test_work_function((void*)0x4243));
     STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(wake_by_address_single(IGNORED_ARG));
 
     sigval_t timer_data = {0};
     timer_data.sival_ptr = timer_instance;

--- a/linux/tests/threadpool_linux_ut/threadpool_linux_ut.c
+++ b/linux/tests/threadpool_linux_ut/threadpool_linux_ut.c
@@ -5,6 +5,9 @@
 #include <stdbool.h>
 #include <semaphore.h>
 #include <time.h>
+#include <bits/types/__sigval_t.h>         // for __sigval_t
+#include <bits/types/sigevent_t.h>         // for sigevent, sigev_notify_fun...
+#include <bits/types/sigval_t.h>           // for sigval_t
 #include <bits/types/timer_t.h>
 
 #include "macro_utils/macro_utils.h" // IWYU pragma: keep
@@ -97,7 +100,10 @@ MOCK_FUNCTION_END(0)
 MOCK_FUNCTION_WITH_CODE(, int, mocked_sem_timedwait, sem_t*, sem, const struct timespec*, abs_timeout)
 MOCK_FUNCTION_END(0)
 
+struct sigevent g_sigevent;
+
 MOCK_FUNCTION_WITH_CODE(, int, mocked_timer_create, clockid_t,clockid, struct sigevent*, sevp, timer_t *, timerid)
+    g_sigevent = *sevp;
    timer_create(clockid, sevp, timerid);
 MOCK_FUNCTION_END(0)
 
@@ -1011,6 +1017,7 @@ TEST_FUNCTION(threadpool_timer_start_with_NULL_timer_handle_fails)
 
 /* Tests_SRS_THREADPOOL_LINUX_07_058: [ threadpool_timer_start shall allocate a context for the timer being started and store work_function and work_function_ctx in it. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_057: [ work_function_ctx shall be allowed to be NULL. ]*/
+/* Tests_SRS_THREADPOOL_LINUX_45_011: [ threadpool_timer_start shall call interlocked_exchange to set the timer_work_guard to OK_TO_WORK. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_059: [ threadpool_timer_start shall call timer_create and timer_settime to schedule execution. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_061: [ threadpool_timer_start shall return and allocated handle in timer_handle. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_062: [ threadpool_timer_start shall succeed and return 0. ]*/
@@ -1040,6 +1047,7 @@ TEST_FUNCTION(threadpool_timer_start_succeeds)
 }
 
 /* Tests_SRS_THREADPOOL_LINUX_07_057: [ work_function_ctx shall be allowed to be NULL. ]*/
+/* Tests_SRS_THREADPOOL_LINUX_45_011: [ threadpool_timer_start shall call interlocked_exchange to set the timer_work_guard to OK_TO_WORK. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_058: [ threadpool_timer_start shall allocate a context for the timer being started and store work_function and work_function_ctx in it. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_059: [ threadpool_timer_start shall call timer_create and timer_settime to schedule execution. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_061: [ threadpool_timer_start shall return and allocated handle in timer_handle. ]*/
@@ -1070,6 +1078,7 @@ TEST_FUNCTION(threadpool_timer_start_with_NULL_work_function_context_succeeds)
 }
 
 /* Tests_SRS_THREADPOOL_LINUX_07_057: [ work_function_ctx shall be allowed to be NULL. ]*/
+/* Tests_SRS_THREADPOOL_LINUX_45_011: [ threadpool_timer_start shall call interlocked_exchange to set the timer_work_guard to OK_TO_WORK. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_058: [ threadpool_timer_start shall allocate a context for the timer being started and store work_function and work_function_ctx in it. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_059: [ threadpool_timer_start shall call timer_create and timer_settime to schedule execution. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_063: [ If timer_settime fails, threadpool_timer_start shall delete the timer by calling timer_delete. ]*/
@@ -1242,6 +1251,10 @@ TEST_FUNCTION(threadpool_timer_destroy_with_NULL_timer_fails)
 
 /* Tests_SRS_THREADPOOL_LINUX_07_071: [ threadpool_timer_cancel shall call timer_delete to destroy the ongoing timers. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_072: [ threadpool_timer_destroy shall free all resources in timer. ]*/
+/* Tests_SRS_THREADPOOL_LINUX_45_007: [ Until timer_work_guard can be set to TIMER_DELETING. ]*/
+/* Tests_SRS_THREADPOOL_LINUX_45_008: [ threadpool_timer_destroy shall call InterlockedHL_WaitForNotValue to wait until timer_work_guard is not TIMER_WORKING. ]*/
+/* Tests_SRS_THREADPOOL_LINUX_45_009: [ threadpool_timer_destroy shall call interlocked_add to add 0 to timer_work_guard to get current value of timer_work_guard. ]*/
+/* Tests_SRS_THREADPOOL_LINUX_45_010: [ threadpool_timer_destroy shall call interlocked_compare_exchange on timer_work_guard with the current value of timer_work_guard as the comparison and TIMER_DELETING as the exchange. ]*/
 TEST_FUNCTION(threadpool_timer_destroy_succeeds)
 {
     // arrange
@@ -1263,6 +1276,78 @@ TEST_FUNCTION(threadpool_timer_destroy_succeeds)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // cleanup
+    THANDLE_ASSIGN(THREADPOOL)(&threadpool, NULL);
+}
+
+/* Tests_SRS_THREADPOOL_LINUX_45_002: [ on_timer_callback shall set the timer instance to timer_data.sival_ptr. ]*/
+/* Tests_SRS_THREADPOOL_LINUX_45_001: [ If timer instance is NULL, then on_timer_callback shall return. ]*/
+/* Tests_SRS_THREADPOOL_LINUX_45_003: [ on_timer_callback shall call interlocked_compare_exchange with the timer_work_guard of this timer instance with OK_TO_WORK as the comparison, and TIMER_WORKING as the exchange. ]*/
+/* Tests_SRS_THREADPOOL_LINUX_45_004: [ If timer_work_guard is successfully set to TIMER_WORKING, then on_timer_callback shall call the timer's work_function with work_function_ctx. ]*/
+/* Tests_SRS_THREADPOOL_LINUX_45_005: [ on_timer_callback shall call interlocked_compare_exchange with the timer_work_guard of this timer instance with TIMER_WORKING as the comparison, and OK_TO_WORK as the exchange. ]*/
+TEST_FUNCTION(on_timer_callback_calls_work_function)
+{
+    // arrange
+    THANDLE(THREADPOOL) threadpool = test_create_and_open_threadpool();
+
+    TIMER_INSTANCE_HANDLE timer_instance;
+    STRICT_EXPECTED_CALL(malloc(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(mocked_timer_create(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(mocked_timer_settime(IGNORED_ARG, 0, IGNORED_ARG, NULL));
+    int result = threadpool_timer_start(threadpool, 42, 2000, test_work_function, (void*)0x4243, &timer_instance);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_IS_NOT_NULL(timer_instance);
+    umock_c_reset_all_calls();
+
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(test_work_function((void*)0x4243));
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, IGNORED_ARG));
+
+    sigval_t timer_data = {0};
+    timer_data.sival_ptr = timer_instance;
+
+    // act
+    g_sigevent.sigev_notify_function(timer_data);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    threadpool_timer_destroy(timer_instance);
+    THANDLE_ASSIGN(THREADPOOL)(&threadpool, NULL);
+}
+
+/* Tests_SRS_THREADPOOL_LINUX_45_002: [ on_timer_callback shall set the timer instance to timer_data.sival_ptr. ]*/
+/* Tests_SRS_THREADPOOL_LINUX_45_001: [ If timer instance is NULL, then on_timer_callback shall return. ]*/
+TEST_FUNCTION(on_timer_callback_does_nothing_with_null_pointer)
+{
+    // arrange
+    THANDLE(THREADPOOL) threadpool = test_create_and_open_threadpool();
+
+    TIMER_INSTANCE_HANDLE timer_instance;
+    STRICT_EXPECTED_CALL(malloc(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(mocked_timer_create(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(mocked_timer_settime(IGNORED_ARG, 0, IGNORED_ARG, NULL));
+    int result = threadpool_timer_start(threadpool, 42, 2000, test_work_function, (void*)0x4243, &timer_instance);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_IS_NOT_NULL(timer_instance);
+    umock_c_reset_all_calls();
+
+    sigval_t timer_data = {0};
+    timer_data.sival_ptr = NULL;
+
+    // act
+    g_sigevent.sigev_notify_function(timer_data);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    threadpool_timer_destroy(timer_instance);
     THANDLE_ASSIGN(THREADPOOL)(&threadpool, NULL);
 }
 

--- a/linux/tests/threadpool_linux_ut/threadpool_linux_ut.c
+++ b/linux/tests/threadpool_linux_ut/threadpool_linux_ut.c
@@ -5,7 +5,6 @@
 #include <stdbool.h>
 #include <semaphore.h>
 #include <time.h>
-#include <bits/types/__sigval_t.h>         // for __sigval_t
 #include <bits/types/sigevent_t.h>         // for sigevent, sigev_notify_fun...
 #include <bits/types/sigval_t.h>           // for sigval_t
 #include <bits/types/timer_t.h>
@@ -52,7 +51,6 @@
 #define MAX_TIMER_INSTANCE_COUNT 64
 
 struct itimerspec;
-struct sigevent;
 struct timespec;
 
 static EXECUTION_ENGINE_PARAMETERS execution_engine = {MIN_THREAD_COUNT, MAX_THREAD_COUNT};

--- a/linux/tests/threadpool_linux_ut/threadpool_linux_ut.c
+++ b/linux/tests/threadpool_linux_ut/threadpool_linux_ut.c
@@ -1251,6 +1251,7 @@ TEST_FUNCTION(threadpool_timer_destroy_with_NULL_timer_fails)
 
 /* Tests_SRS_THREADPOOL_LINUX_07_071: [ threadpool_timer_cancel shall call timer_delete to destroy the ongoing timers. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_072: [ threadpool_timer_destroy shall free all resources in timer. ]*/
+/* Tests_SRS_THREADPOOL_LINUX_45_012: [ threadpool_timer_cancel shall call ThreadAPI_Sleep to allow timer resources to clean up. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_45_007: [ Until timer_work_guard can be set to TIMER_DELETING. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_45_008: [ threadpool_timer_destroy shall call InterlockedHL_WaitForNotValue to wait until timer_work_guard is not TIMER_WORKING. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_45_009: [ threadpool_timer_destroy shall call interlocked_add to add 0 to timer_work_guard to get current value of timer_work_guard. ]*/

--- a/linux/tests/threadpool_linux_ut/threadpool_linux_ut.c
+++ b/linux/tests/threadpool_linux_ut/threadpool_linux_ut.c
@@ -1022,6 +1022,7 @@ TEST_FUNCTION(threadpool_timer_start_succeeds)
     TIMER_INSTANCE_HANDLE timer_instance;
 
     STRICT_EXPECTED_CALL(malloc(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(mocked_timer_create(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(mocked_timer_settime(IGNORED_ARG, 0, IGNORED_ARG, NULL));
 
@@ -1051,6 +1052,7 @@ TEST_FUNCTION(threadpool_timer_start_with_NULL_work_function_context_succeeds)
     TIMER_INSTANCE_HANDLE timer_instance;
 
     STRICT_EXPECTED_CALL(malloc(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(mocked_timer_create(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(mocked_timer_settime(IGNORED_ARG, 0, IGNORED_ARG, NULL));
 
@@ -1079,6 +1081,7 @@ TEST_FUNCTION(threadpool_timer_start_delete_timer_when_timer_set_time_functions_
     TIMER_INSTANCE_HANDLE timer_instance;
 
     STRICT_EXPECTED_CALL(malloc(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(mocked_timer_create(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(mocked_timer_settime(IGNORED_ARG, 0, IGNORED_ARG, NULL)).SetReturn(-1);
     STRICT_EXPECTED_CALL(mocked_timer_delete(IGNORED_ARG));
@@ -1103,6 +1106,7 @@ TEST_FUNCTION(threadpool_timer_start_fails_when_underlying_functions_fail)
     TIMER_INSTANCE_HANDLE timer_instance;
 
     STRICT_EXPECTED_CALL(malloc(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, IGNORED_ARG)).CallCannotFail();
     STRICT_EXPECTED_CALL(mocked_timer_create(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(mocked_timer_settime(IGNORED_ARG, 0, IGNORED_ARG, NULL));
 
@@ -1245,7 +1249,11 @@ TEST_FUNCTION(threadpool_timer_destroy_succeeds)
     TIMER_INSTANCE_HANDLE timer_instance;
     test_create_threadpool_and_start_timer(42, 2000, (void*)0x4243, &threadpool, &timer_instance);
 
+    STRICT_EXPECTED_CALL(InterlockedHL_WaitForNotValue(IGNORED_ARG, IGNORED_ARG, UINT32_MAX));
+    STRICT_EXPECTED_CALL(interlocked_add(IGNORED_ARG, 0));
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, IGNORED_ARG,IGNORED_ARG));
     STRICT_EXPECTED_CALL(mocked_timer_delete(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(ThreadAPI_Sleep(IGNORED_ARG));
     STRICT_EXPECTED_CALL(free(IGNORED_ARG));
 
     // act


### PR DESCRIPTION
Add a guard around the work function in timer callback so the timer can not be deleted while the event has been triggered.
Add a slight delay on timer destroy to allow thread cleanup and prevent the timer from being executed even though timer has been destroyed.