### PR TITLE
Added method to get time elapsed in seconds without creating a timer

### DIFF
--- a/interfaces/devdoc/timer_requirements.md
+++ b/interfaces/devdoc/timer_requirements.md
@@ -14,6 +14,7 @@ MOCKABLE_FUNCTION(, int, timer_start, TIMER_HANDLE, handle);
 MOCKABLE_FUNCTION(, double, timer_get_elapsed, TIMER_HANDLE, timer);
 MOCKABLE_FUNCTION(, double, timer_get_elapsed_ms, TIMER_HANDLE, timer);
 MOCKABLE_FUNCTION(, void, timer_destroy, TIMER_HANDLE, timer);
+MOCKABLE_FUNCTION(, double, timer_global_get_elapsed);
 MOCKABLE_FUNCTION(, double, timer_global_get_elapsed_ms);
 MOCKABLE_FUNCTION(, double, timer_global_get_elapsed_us);
 ```

--- a/interfaces/devdoc/timer_requirements.md
+++ b/interfaces/devdoc/timer_requirements.md
@@ -76,6 +76,16 @@ MOCKABLE_FUNCTION(, double, timer_get_elapsed_ms, TIMER_HANDLE, timer);
 
 **SRS_TIMER_01_009: [** Otherwise `timer_get_elapsed_ms` shall return the time difference in milliseconds between the current time and the start time of the timer. **]**
 
+### timer_global_get_elapsed
+
+```c
+MOCKABLE_FUNCTION(, double, timer_global_get_elapsed);
+```
+
+`timer_global_get_elapsed` returns the elapsed time in seconds from a start time in the past (the actual point in time is unspecified).
+
+**SRS_TIMER_27_001: [** `timer_global_get_elapsed` shall return the elapsed time in seconds from a start time in the past. **]**
+
 ### timer_global_get_elapsed_ms
 
 ```c

--- a/interfaces/devdoc/timer_requirements.md
+++ b/interfaces/devdoc/timer_requirements.md
@@ -14,7 +14,7 @@ MOCKABLE_FUNCTION(, int, timer_start, TIMER_HANDLE, handle);
 MOCKABLE_FUNCTION(, double, timer_get_elapsed, TIMER_HANDLE, timer);
 MOCKABLE_FUNCTION(, double, timer_get_elapsed_ms, TIMER_HANDLE, timer);
 MOCKABLE_FUNCTION(, void, timer_destroy, TIMER_HANDLE, timer);
-MOCKABLE_FUNCTION(, double, timer_global_get_elapsed);
+MOCKABLE_FUNCTION(, double, timer_global_get_elapsed_s);
 MOCKABLE_FUNCTION(, double, timer_global_get_elapsed_ms);
 MOCKABLE_FUNCTION(, double, timer_global_get_elapsed_us);
 ```
@@ -77,15 +77,15 @@ MOCKABLE_FUNCTION(, double, timer_get_elapsed_ms, TIMER_HANDLE, timer);
 
 **SRS_TIMER_01_009: [** Otherwise `timer_get_elapsed_ms` shall return the time difference in milliseconds between the current time and the start time of the timer. **]**
 
-### timer_global_get_elapsed
+### timer_global_get_elapsed_s
 
 ```c
-MOCKABLE_FUNCTION(, double, timer_global_get_elapsed);
+MOCKABLE_FUNCTION(, double, timer_global_get_elapsed_s);
 ```
 
-`timer_global_get_elapsed` returns the elapsed time in seconds from a start time in the past (the actual point in time is unspecified).
+`timer_global_get_elapsed_s` returns the elapsed time in seconds from a start time in the past (the actual point in time is unspecified).
 
-**SRS_TIMER_27_001: [** `timer_global_get_elapsed` shall return the elapsed time in seconds from a start time in the past. **]**
+**SRS_TIMER_27_001: [** `timer_global_get_elapsed_s` shall return the elapsed time in seconds from a start time in the past. **]**
 
 ### timer_global_get_elapsed_ms
 

--- a/interfaces/inc/c_pal/timer.h
+++ b/interfaces/inc/c_pal/timer.h
@@ -18,6 +18,7 @@ MOCKABLE_FUNCTION(, int, timer_start, TIMER_HANDLE, handle);
 MOCKABLE_FUNCTION(, double, timer_get_elapsed, TIMER_HANDLE, timer);
 MOCKABLE_FUNCTION(, double, timer_get_elapsed_ms, TIMER_HANDLE, timer);
 MOCKABLE_FUNCTION(, void, timer_destroy, TIMER_HANDLE, timer);
+MOCKABLE_FUNCTION(, void, global_timer_state_reset);
 MOCKABLE_FUNCTION(, double, timer_global_get_elapsed);
 MOCKABLE_FUNCTION(, double, timer_global_get_elapsed_ms);
 MOCKABLE_FUNCTION(, double, timer_global_get_elapsed_us);

--- a/interfaces/inc/c_pal/timer.h
+++ b/interfaces/inc/c_pal/timer.h
@@ -19,7 +19,7 @@ MOCKABLE_FUNCTION(, double, timer_get_elapsed, TIMER_HANDLE, timer);
 MOCKABLE_FUNCTION(, double, timer_get_elapsed_ms, TIMER_HANDLE, timer);
 MOCKABLE_FUNCTION(, void, timer_destroy, TIMER_HANDLE, timer);
 MOCKABLE_FUNCTION(, void, global_timer_state_reset);
-MOCKABLE_FUNCTION(, double, timer_global_get_elapsed);
+MOCKABLE_FUNCTION(, double, timer_global_get_elapsed_s);
 MOCKABLE_FUNCTION(, double, timer_global_get_elapsed_ms);
 MOCKABLE_FUNCTION(, double, timer_global_get_elapsed_us);
 

--- a/interfaces/inc/c_pal/timer.h
+++ b/interfaces/inc/c_pal/timer.h
@@ -18,6 +18,7 @@ MOCKABLE_FUNCTION(, int, timer_start, TIMER_HANDLE, handle);
 MOCKABLE_FUNCTION(, double, timer_get_elapsed, TIMER_HANDLE, timer);
 MOCKABLE_FUNCTION(, double, timer_get_elapsed_ms, TIMER_HANDLE, timer);
 MOCKABLE_FUNCTION(, void, timer_destroy, TIMER_HANDLE, timer);
+MOCKABLE_FUNCTION(, double, timer_global_get_elapsed);
 MOCKABLE_FUNCTION(, double, timer_global_get_elapsed_ms);
 MOCKABLE_FUNCTION(, double, timer_global_get_elapsed_us);
 

--- a/interfaces/reals/real_timer.h
+++ b/interfaces/reals/real_timer.h
@@ -32,6 +32,8 @@ double real_timer_get_elapsed(TIMER_HANDLE handle);
 
 double real_timer_get_elapsed_ms(TIMER_HANDLE handle);
 
+double real_timer_global_get_elapsed_s(void);
+
 double real_timer_global_get_elapsed_ms(void);
 
 double real_timer_global_get_elapsed_us(void);

--- a/interfaces/reals/real_timer.h
+++ b/interfaces/reals/real_timer.h
@@ -32,6 +32,8 @@ double real_timer_get_elapsed(TIMER_HANDLE handle);
 
 double real_timer_get_elapsed_ms(TIMER_HANDLE handle);
 
+void real_global_timer_state_reset(void);
+
 double real_timer_global_get_elapsed_s(void);
 
 double real_timer_global_get_elapsed_ms(void);

--- a/interfaces/reals/real_timer_renames.h
+++ b/interfaces/reals/real_timer_renames.h
@@ -6,5 +6,6 @@
 #define timer_get_elapsed               real_timer_get_elapsed
 #define timer_get_elapsed_ms            real_timer_get_elapsed_ms
 #define timer_destroy                   real_timer_destroy
+#define timer_global_get_elapsed_s      real_timer_global_get_elapsed_s
 #define timer_global_get_elapsed_ms     real_timer_global_get_elapsed_ms
 #define timer_global_get_elapsed_us     real_timer_global_get_elapsed_us

--- a/interfaces/reals/real_timer_renames.h
+++ b/interfaces/reals/real_timer_renames.h
@@ -6,6 +6,7 @@
 #define timer_get_elapsed               real_timer_get_elapsed
 #define timer_get_elapsed_ms            real_timer_get_elapsed_ms
 #define timer_destroy                   real_timer_destroy
+#define global_timer_state_reset        real_global_timer_state_reset
 #define timer_global_get_elapsed_s      real_timer_global_get_elapsed_s
 #define timer_global_get_elapsed_ms     real_timer_global_get_elapsed_ms
 #define timer_global_get_elapsed_us     real_timer_global_get_elapsed_us

--- a/interfaces/tests/timer_int/timer_int.c
+++ b/interfaces/tests/timer_int/timer_int.c
@@ -253,6 +253,26 @@ TEST_FUNCTION(timer_get_elapsed_ms_with_start_succeeds)
 
 /* timer_global_get_elapsed_ms */
 
+/* Tests_SRS_TIMER_27_001: [ timer_global_get_elapsed_s shall return the elapsed time in seconds from a start time in the past. ]*/
+TEST_FUNCTION(timer_global_get_elapsed_s_measures_a_seconds)
+{
+    ///arrange
+
+    // sleep 1s
+    double start = timer_global_get_elapsed_s();
+    ThreadAPI_Sleep(1000);
+
+    ///act
+    double end = timer_global_get_elapsed_s();
+
+    ///assert
+    /// giving it a wide tolerance
+    ASSERT_IS_TRUE((end - start) > 0.5);
+    ASSERT_IS_TRUE((end - start) < 1.5);
+}
+
+/* timer_global_get_elapsed_ms */
+
 /* Tests_SRS_TIMER_01_010: [ timer_global_get_elapsed_ms shall return the elapsed time in milliseconds from a start time in the past. ]*/
 TEST_FUNCTION(timer_global_get_elapsed_ms_measures_a_seconds)
 {

--- a/linux/devdoc/timer_linux_requirements.md
+++ b/linux/devdoc/timer_linux_requirements.md
@@ -14,6 +14,7 @@ MOCKABLE_FUNCTION(, int, timer_start, TIMER_HANDLE, handle);
 MOCKABLE_FUNCTION(, double, timer_get_elapsed, TIMER_HANDLE, timer);
 MOCKABLE_FUNCTION(, double, timer_get_elapsed_ms, TIMER_HANDLE, timer);
 MOCKABLE_FUNCTION(, void, timer_destroy, TIMER_HANDLE, timer);
+MOCKABLE_FUNCTION(, double, timer_global_get_elapsed_s);
 MOCKABLE_FUNCTION(, double, timer_global_get_elapsed_ms);
 MOCKABLE_FUNCTION(, double, timer_global_get_elapsed_us);
 ```
@@ -89,6 +90,20 @@ MOCKABLE_FUNCTION(, double, timer_get_elapsed_ms, TIMER_HANDLE, timer);
 **SRS_TIMER_LINUX_01_013: [** `timer_get_elapsed_ms` shall return the time difference in milliseconds between the current time and the start time of the timer. **]**
 
 **SRS_TIMER_LINUX_01_021: [** If any error occurs, `timer_get_elapsed_ms` shall fail and return -1. **]**
+
+### timer_global_get_elapsed_s
+
+```c
+MOCKABLE_FUNCTION(, double, timer_global_get_elapsed_s);
+```
+
+`timer_global_get_elapsed_s` returns the elapsed time in seconds from a start time in the past (the actual point in time is unspecified).
+
+**SRS_TIMER_LINUX_27_001: [** `timer_global_get_elapsed_s` shall call `clock_gettime` with `CLOCK_MONOTONIC` to obtain the current timer value. **]**
+
+**SRS_TIMER_LINUX_27_002: [** `timer_global_get_elapsed_s` shall return the elapsed time in seconds (as returned by `clock_gettime`). **]**
+
+**SRS_TIMER_LINUX_27_003: [** If any error occurs, `timer_global_get_elapsed_s` shall return -1. **]**
 
 ### timer_global_get_elapsed_ms
 

--- a/linux/src/timer_linux.c
+++ b/linux/src/timer_linux.c
@@ -180,6 +180,28 @@ double timer_get_elapsed_ms(TIMER_HANDLE timer)
     return result;
 }
 
+double timer_global_get_elapsed_s(void)
+{
+    double result;
+    struct timespec elapsed_time;
+
+    /* Codes_SRS_TIMER_27_001: [ timer_global_get_elapsed_s shall return the elapsed time in seconds from a start time in the past. ]*/
+    /* Codes_SRS_TIMER_LINUX_27_001: [ timer_global_get_elapsed_s shall call clock_gettime with CLOCK_MONOTONIC to obtain the current timer value. ]*/
+    if (clock_gettime(CLOCK_MONOTONIC, &elapsed_time) < 0)
+    {
+        /* Codes_SRS_TIMER_LINUX_27_003: [ If any error occurs, timer_global_get_elapsed_s shall return -1. ]*/
+        LogError("clock_gettime failed");
+        result = -1.0;
+    }
+    else
+    {
+        /* Codes_SRS_TIMER_LINUX_27_002: [ timer_global_get_elapsed_s shall return the elapsed time in seconds (as returned by clock_gettime). ]*/
+        result = (double)elapsed_time.tv_sec;
+        result += (double)elapsed_time.tv_nsec / 1000000000;
+    }
+    return result;
+}
+
 double timer_global_get_elapsed_ms(void)
 {
     double result;

--- a/linux/tests/timer_linux_ut/timer_linux_ut.c
+++ b/linux/tests/timer_linux_ut/timer_linux_ut.c
@@ -437,6 +437,51 @@ TEST_FUNCTION(when_clock_gettime_fails_timer_get_elapsed_ms_also_fails)
     timer_destroy(timer);
 }
 
+/* timer_global_get_elapsed_s */
+
+/* Tests_SRS_TIMER_LINUX_27_001: [ timer_global_get_elapsed_s shall call clock_gettime with CLOCK_MONOTONIC to obtain the current timer value. ]*/
+/* Tests_SRS_TIMER_LINUX_27_002: [ timer_global_get_elapsed_s shall return the elapsed time in seconds (as returned by clock_gettime). ]*/
+TEST_FUNCTION(timer_global_get_elapsed_s_succeeds)
+{
+    ///arrange
+    struct timespec time_1;
+    time_1.tv_sec = 0;
+    time_1.tv_nsec = 0;
+    STRICT_EXPECTED_CALL(mocked_clock_gettime(CLOCK_MONOTONIC, IGNORED_ARG))
+        .CopyOutArgumentBuffer_tp(&time_1, sizeof(time_1));
+    struct timespec time_2;
+    time_2.tv_sec = 9;
+    time_2.tv_nsec = 900000000;
+    STRICT_EXPECTED_CALL(mocked_clock_gettime(CLOCK_MONOTONIC, IGNORED_ARG))
+        .CopyOutArgumentBuffer_tp(&time_2, sizeof(time_2));
+
+    ///act
+    double elapsed1 = timer_global_get_elapsed_s();
+    double elapsed2 = timer_global_get_elapsed_s();
+
+    ASSERT_IS_TRUE(elapsed1 == 0.0);
+    ASSERT_IS_TRUE(elapsed2 == 9.9);
+
+    //assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+/* Tests_SRS_TIMER_LINUX_27_003: [ If any error occurs, timer_global_get_elapsed_s shall return -1. ]*/
+TEST_FUNCTION(when_clock_gettime_fails_timer_global_get_elapsed_s_also_fails)
+{
+    ///arrange
+    STRICT_EXPECTED_CALL(mocked_clock_gettime(CLOCK_MONOTONIC, IGNORED_ARG))
+        .SetReturn(-1);
+
+    ///act
+    double elapsed = timer_global_get_elapsed_s();
+
+    ASSERT_IS_TRUE(elapsed == -1.0);
+
+    //assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
 /* timer_global_get_elapsed_ms */
 
 /* Tests_SRS_TIMER_LINUX_01_014: [ timer_global_get_elapsed_ms shall call clock_gettime with CLOCK_MONOTONIC to obtain the current timer value. ]*/
@@ -519,7 +564,7 @@ TEST_FUNCTION(when_clock_gettime_fails_timer_global_get_elapsed_us_also_fails)
         .SetReturn(-1);
 
     ///act
-    double elapsed = timer_global_get_elapsed_ms();
+    double elapsed = timer_global_get_elapsed_us();
 
     ASSERT_IS_TRUE(elapsed == -1.0);
 

--- a/win32/src/timer_win32.c
+++ b/win32/src/timer_win32.c
@@ -95,6 +95,21 @@ void timer_destroy(TIMER_HANDLE timer)
 static LARGE_INTEGER g_freq;
 static volatile LONG g_timer_state = 0; /*0 - not "created", 1 - "created", "2" - creating*/
 
+/*returns a time in seconds since "some" start.*/
+double timer_global_get_elapsed(void)
+{
+    while (InterlockedCompareExchange(&g_timer_state, 2, 0) != 1)
+    {
+        (void)QueryPerformanceFrequency(&g_freq); /*from MSDN:  On systems that run Windows XP or later, the function will always succeed and will thus never return zero.*/
+        (void)InterlockedExchange(&g_timer_state, 1);
+    }
+
+    /* Codes_SRS_TIMER_27_001: [ timer_global_get_elapsed shall return the elapsed time in seconds from a start time in the past. ]*/
+    LARGE_INTEGER now;
+    (void)QueryPerformanceCounter(&now);
+    return (double)now.QuadPart / (double)g_freq.QuadPart;
+}
+
 /*returns a time in ms since "some" start.*/
 double timer_global_get_elapsed_ms(void)
 {

--- a/win32/src/timer_win32.c
+++ b/win32/src/timer_win32.c
@@ -95,6 +95,11 @@ void timer_destroy(TIMER_HANDLE timer)
 static LARGE_INTEGER g_freq;
 static volatile LONG g_timer_state = 0; /*0 - not "created", 1 - "created", "2" - creating*/
 
+void global_timer_state_reset(void)
+{
+    (void)InterlockedExchange(&g_timer_state, 0);
+}
+
 /*returns a time in seconds since "some" start.*/
 double timer_global_get_elapsed(void)
 {
@@ -107,7 +112,7 @@ double timer_global_get_elapsed(void)
     /* Codes_SRS_TIMER_27_001: [ timer_global_get_elapsed shall return the elapsed time in seconds from a start time in the past. ]*/
     LARGE_INTEGER now;
     (void)QueryPerformanceCounter(&now);
-    return (double)now.QuadPart / (double)g_freq.QuadPart;
+    return (double)now.QuadPart/ (double)g_freq.QuadPart;
 }
 
 /*returns a time in ms since "some" start.*/

--- a/win32/src/timer_win32.c
+++ b/win32/src/timer_win32.c
@@ -101,7 +101,7 @@ void global_timer_state_reset(void)
 }
 
 /*returns a time in seconds since "some" start.*/
-double timer_global_get_elapsed(void)
+double timer_global_get_elapsed_s(void)
 {
     while (InterlockedCompareExchange(&g_timer_state, 2, 0) != 1)
     {
@@ -109,7 +109,7 @@ double timer_global_get_elapsed(void)
         (void)InterlockedExchange(&g_timer_state, 1);
     }
 
-    /* Codes_SRS_TIMER_27_001: [ timer_global_get_elapsed shall return the elapsed time in seconds from a start time in the past. ]*/
+    /* Codes_SRS_TIMER_27_001: [ timer_global_get_elapsed_s shall return the elapsed time in seconds from a start time in the past. ]*/
     LARGE_INTEGER now;
     (void)QueryPerformanceCounter(&now);
     return (double)now.QuadPart/ (double)g_freq.QuadPart;

--- a/win32/tests/timer_win32_ut/timer_win32_ut.c
+++ b/win32/tests/timer_win32_ut/timer_win32_ut.c
@@ -262,8 +262,8 @@ TEST_FUNCTION(g_timer_get_elapsed_in_seconds_succeeds)
         .CopyOutArgumentBuffer_lpPerformanceCount(&pretendCounter2, sizeof(pretendCounter2));
 
     ///act
-    double elapsed1 = timer_global_get_elapsed();
-    double elapsed2 = timer_global_get_elapsed();
+    double elapsed1 = timer_global_get_elapsed_s();
+    double elapsed2 = timer_global_get_elapsed_s();
 
     ASSERT_IS_TRUE(elapsed1 == 2.0); /* all integer number up to 2^31 are perfectly representable by double*/
 

--- a/win32/tests/timer_win32_ut/timer_win32_ut.c
+++ b/win32/tests/timer_win32_ut/timer_win32_ut.c
@@ -69,6 +69,7 @@ TEST_SUITE_CLEANUP(suite_cleanup)
 
 TEST_FUNCTION_INITIALIZE(init)
 {
+    global_timer_state_reset();
     umock_c_reset_all_calls();
 }
 
@@ -240,7 +241,7 @@ TEST_FUNCTION(timer_destroy_frees_handle)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-TEST_FUNCTION(g_timer_get_elapsed_succeeds)
+TEST_FUNCTION(g_timer_get_elapsed_in_seconds_succeeds)
 {
     ///arrange
     LARGE_INTEGER pretendFreq;
@@ -299,6 +300,39 @@ TEST_FUNCTION(g_timer_get_elapsed_in_ms_succeeds)
     ASSERT_IS_TRUE(elapsed1 == 2000.0); /* all integer number up to 2^31 are perfectly representable by double*/
 
     ASSERT_IS_TRUE(elapsed2 == 5000.0); /* all integer number up to 2^31 are perfectly representable by double*/
+
+    //assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+TEST_FUNCTION(g_timer_get_elapsed_in_us_succeeds)
+{
+
+    ///arrange
+    LARGE_INTEGER pretendFreq;
+    pretendFreq.QuadPart = 1000;
+
+    STRICT_EXPECTED_CALL(mocked_QueryPerformanceFrequency(IGNORED_ARG))
+        .CopyOutArgumentBuffer_lpFrequency(&pretendFreq, sizeof(pretendFreq));
+
+    LARGE_INTEGER pretendCounter1;
+    pretendCounter1.QuadPart = 2000;
+    STRICT_EXPECTED_CALL(mocked_QueryPerformanceCounter(IGNORED_ARG))
+        .CopyOutArgumentBuffer_lpPerformanceCount(&pretendCounter1, sizeof(pretendCounter1));
+
+    /*note: missing second QueryPerformanceFrequency*/
+    LARGE_INTEGER pretendCounter2;
+    pretendCounter2.QuadPart = 5000;
+    STRICT_EXPECTED_CALL(mocked_QueryPerformanceCounter(IGNORED_ARG))
+        .CopyOutArgumentBuffer_lpPerformanceCount(&pretendCounter2, sizeof(pretendCounter2));
+
+    ///act
+    double elapsed1 = timer_global_get_elapsed_us();
+    double elapsed2 = timer_global_get_elapsed_us();
+
+    ASSERT_IS_TRUE(elapsed1 == 2000000.0); /* all integer number up to 2^31 are perfectly representable by double*/
+
+    ASSERT_IS_TRUE(elapsed2 == 5000000.0); /* all integer number up to 2^31 are perfectly representable by double*/
 
     //assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());

--- a/win32/tests/timer_win32_ut/timer_win32_ut.c
+++ b/win32/tests/timer_win32_ut/timer_win32_ut.c
@@ -241,6 +241,7 @@ TEST_FUNCTION(timer_destroy_frees_handle)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
+/* Tests_SRS_TIMER_27_001: [timer_global_get_elapsed_s shall return the elapsed time in seconds from a start time in the past.**] */
 TEST_FUNCTION(g_timer_get_elapsed_in_seconds_succeeds)
 {
     ///arrange

--- a/win32/tests/timer_win32_ut/timer_win32_ut.c
+++ b/win32/tests/timer_win32_ut/timer_win32_ut.c
@@ -240,6 +240,38 @@ TEST_FUNCTION(timer_destroy_frees_handle)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
+TEST_FUNCTION(g_timer_get_elapsed_succeeds)
+{
+    ///arrange
+    LARGE_INTEGER pretendFreq;
+    pretendFreq.QuadPart = 1000;
+
+    STRICT_EXPECTED_CALL(mocked_QueryPerformanceFrequency(IGNORED_ARG))
+        .CopyOutArgumentBuffer_lpFrequency(&pretendFreq, sizeof(pretendFreq));
+
+    LARGE_INTEGER pretendCounter1;
+    pretendCounter1.QuadPart = 2000;
+    STRICT_EXPECTED_CALL(mocked_QueryPerformanceCounter(IGNORED_ARG))
+        .CopyOutArgumentBuffer_lpPerformanceCount(&pretendCounter1, sizeof(pretendCounter1));
+
+    /*note: missing second QueryPerformanceFrequency*/
+    LARGE_INTEGER pretendCounter2;
+    pretendCounter2.QuadPart = 5000;
+    STRICT_EXPECTED_CALL(mocked_QueryPerformanceCounter(IGNORED_ARG))
+        .CopyOutArgumentBuffer_lpPerformanceCount(&pretendCounter2, sizeof(pretendCounter2));
+
+    ///act
+    double elapsed1 = timer_global_get_elapsed();
+    double elapsed2 = timer_global_get_elapsed();
+
+    ASSERT_IS_TRUE(elapsed1 == 2.0); /* all integer number up to 2^31 are perfectly representable by double*/
+
+    ASSERT_IS_TRUE(elapsed2 == 5.0); /* all integer number up to 2^31 are perfectly representable by double*/
+
+    //assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
 TEST_FUNCTION(g_timer_get_elapsed_in_ms_succeeds)
 {
     ///arrange


### PR DESCRIPTION
## Summary

This pull request introduces a new method `timer_global_get_elapsed` to get the time elapsed in seconds without the need to create a timer. This method is useful for avoid using malloc for creating timer.

## Changes

- Added `timer_global_get_elapsed` method to return the elapsed time in seconds from a start time in the past.
- Added a reset function `global_timer_state_reset` to reset the global timer state between tests.

## Testing

- Verified the functionality with unit tests to ensure the correct elapsed time is returned.
- Added tests to check the reset functionality to avoid state interference between tests.
