### PR TITLE
Threadpool WIN32 changes implementation

### DIFF
--- a/interfaces/devdoc/threadpool_requirements.md
+++ b/interfaces/devdoc/threadpool_requirements.md
@@ -149,16 +149,18 @@ MOCKABLE_FUNCTION(, int, threadpool_schedule_work_item, THANDLE(THREADPOOL), thr
 ### threadpool_destroy_work_item
 
 ```c
-MOCKABLE_FUNCTION(, void, threadpool_destroy_work_item, THREADPOOL_WORK_ITEM_HANDLE, work_item_context);
+MOCKABLE_FUNCTION(, void, threadpool_destroy_work_item, THANDLE(THREADPOOL), threadpool, THREADPOOL_WORK_ITEM_HANDLE, work_item_context);
 ```
 
 `threadpool_destroy_work_item` closes and frees all the member variables in the context of type `THREADPOOL_WORK_ITEM_HANDLE` and then frees the context
 
-**NON_THREADPOOL_05_011: [** If `work_item_context` is `NULL`, `threadpool_destroy_work_item` shall fail and not do anything before returning. **]**
+**NON_THREADPOOL_05_011: [ ** If `threadpool` is `NULL`, `threadpool_destroy_work_item` shall fail and return a `non-zero` value. **]**
 
-**NON_THREADPOOL_05_012: [** `threadpool_destroy_work_item` shall close and free all the members of `THREADPOOL_WORK_ITEM_HANDLE`. **]**
+**NON_THREADPOOL_05_012: [** If `work_item_context` is `NULL`, `threadpool_destroy_work_item` shall fail and not do anything before returning. **]**
 
-**NON_THREADPOOL_05_013: [** `threadpool_destroy_work_item` shall free the `work_item_context` of type `THREADPOOL_WORK_ITEM_HANDLE`. **]**
+**NON_THREADPOOL_05_013: [** `threadpool_destroy_work_item` shall close and free all the members of `THREADPOOL_WORK_ITEM_HANDLE`. **]**
+
+**NON_THREADPOOL_05_014: [** `threadpool_destroy_work_item` shall free the `work_item_context` of type `THREADPOOL_WORK_ITEM_HANDLE`. **]**
 
 ### threadpool_schedule_work
 

--- a/interfaces/inc/c_pal/threadpool.h
+++ b/interfaces/inc/c_pal/threadpool.h
@@ -36,7 +36,7 @@ MOCKABLE_FUNCTION(, THREADPOOL_WORK_ITEM_HANDLE, threadpool_create_work_item, TH
 
 MOCKABLE_FUNCTION(, int, threadpool_schedule_work_item, THANDLE(THREADPOOL), threadpool, THREADPOOL_WORK_ITEM_HANDLE, work_item_context);
 
-MOCKABLE_FUNCTION(, void, threadpool_destroy_work_item, THREADPOOL_WORK_ITEM_HANDLE, work_item_context);
+MOCKABLE_FUNCTION(, void, threadpool_destroy_work_item, THANDLE(THREADPOOL), threadpool, THREADPOOL_WORK_ITEM_HANDLE, work_item_context);
 
 MOCKABLE_FUNCTION(, int, threadpool_schedule_work, THANDLE(THREADPOOL), threadpool, THREADPOOL_WORK_FUNCTION, work_function, void*, work_function_context);
 

--- a/linux/devdoc/threadpool_linux_requirements.md
+++ b/linux/devdoc/threadpool_linux_requirements.md
@@ -445,9 +445,11 @@ MOCKABLE_FUNCTION(, int, threadpool_schedule_work_item, THANDLE(THREADPOOL), thr
 ### threadpool_destroy_work_item
 
 ```c
-MOCKABLE_FUNCTION(, void, threadpool_destroy_work_item, THREADPOOL_WORK_ITEM_HANDLE, work_item_context);
+MOCKABLE_FUNCTION(, void, threadpool_destroy_work_item, THANDLE(THREADPOOL), threadpool, THREADPOOL_WORK_ITEM_HANDLE, work_item_context);
 ```
 
-`threadpool_work_context_destroy` Does nothing and a placeholder for WIN32 equivalent function stub
+`threadpool_destroy_work_item` Does nothing and a placeholder for WIN32 equivalent function stub
 
-**S_R_S_THREADPOOL_LINUX_05_020: [** `threadpool_work_context_destroy` shall free the memory allocated to the work item of type `THREADPOOL_WORK_ITEM_HANDLE` created in `threadpool_create_work_item`. **]**
+**S_R_S_THREADPOOL_LINUX_05_020: [ ** If `threadpool` is `NULL`, `threadpool_destroy_work_item` shall fail and return a `non-zero` value. **]**
+
+**S_R_S_THREADPOOL_LINUX_05_021: [** `threadpool_work_context_destroy` shall free the memory allocated to the work item of type `THREADPOOL_WORK_ITEM_HANDLE` created in `threadpool_create_work_item`. **]**

--- a/linux/linux_reals/real_threadpool.h
+++ b/linux/linux_reals/real_threadpool.h
@@ -38,7 +38,7 @@ extern "C" {
     void real_threadpool_close(THANDLE(THREADPOOL) threadpool);
     THREADPOOL_WORK_ITEM_HANDLE real_threadpool_create_work_item(THANDLE(THREADPOOL) threadpool, THREADPOOL_WORK_FUNCTION work_function, void* work_function_context);
     int real_threadpool_schedule_work_item(THANDLE(THREADPOOL) threadpool, THREADPOOL_WORK_ITEM_HANDLE work_item_context);
-    void real_threadpool_destroy_work_item(THREADPOOL_WORK_ITEM_HANDLE work_item_context);
+    void real_threadpool_destroy_work_item(THANDLE(THREADPOOL) threadpool, THREADPOOL_WORK_ITEM_HANDLE work_item_context);
     int real_threadpool_schedule_work(THANDLE(THREADPOOL) threadpool, THREADPOOL_WORK_FUNCTION work_function, void* work_function_context);
     int real_threadpool_timer_start(THANDLE(THREADPOOL) threadpool, uint32_t start_delay_ms, uint32_t timer_period_ms, THREADPOOL_WORK_FUNCTION work_function, void* work_function_context, TIMER_INSTANCE_HANDLE* timer_handle);
     int real_threadpool_timer_restart(TIMER_INSTANCE_HANDLE timer, uint32_t start_delay_ms, uint32_t timer_period_ms);

--- a/linux/src/threadpool_linux.c
+++ b/linux/src/threadpool_linux.c
@@ -527,7 +527,7 @@ int threadpool_schedule_work_item(THANDLE(THREADPOOL) threadpool, THREADPOOL_WOR
     return 0;
 }
 
-static void threadpool_work_context_destroy(THREADPOOL_WORK_ITEM_HANDLE work_item_context)
+void threadpool_destroy_work_item(THANDLE(THREADPOOL) threadpool, THREADPOOL_WORK_ITEM_HANDLE work_item_context)
 {
     LogWarning("Not Implemented: threadpool_work_context_destroy(%p)", work_item_context);
 }

--- a/win32/devdoc/threadpool_win32.md
+++ b/win32/devdoc/threadpool_win32.md
@@ -27,7 +27,7 @@ MOCKABLE_FUNCTION(, THREADPOOL_WORK_ITEM_HANDLE, threadpool_create_work_item, TH
 
 MOCKABLE_FUNCTION(, int, threadpool_schedule_work_item, THANDLE(THREADPOOL), threadpool, THREADPOOL_WORK_ITEM_HANDLE, work_item_context);
 
-MOCKABLE_FUNCTION(, void, threadpool_destroy_work_item, THREADPOOL_WORK_ITEM_HANDLE, work_item_context);
+MOCKABLE_FUNCTION(, void, threadpool_destroy_work_item, THANDLE(THREADPOOL), threadpool, THREADPOOL_WORK_ITEM_HANDLE, work_item_context);
 
 MOCKABLE_FUNCTION(, int, threadpool_schedule_work, THANDLE(THREADPOOL), threadpool, THREADPOOL_WORK_FUNCTION, work_function, void*, work_function_context);
 
@@ -170,11 +170,11 @@ static VOID CALLBACK on_work_callback_v2(PTP_CALLBACK_INSTANCE instance, void* c
 
 `on_work_callback_v2` executes the work function passed to `threadpool_create_work_item`.
 
-**S_R_S_THREADPOOL_WIN32_05_001: [** If `context` is `NULL`, `on_work_callback_v2` shall return. **]**
+**SRS_THREADPOOL_WIN32_05_001: [** If `context` is `NULL`, `on_work_callback_v2` shall return. **]**
 
-**S_R_S_THREADPOOL_WIN32_05_002: [** Otherwise `context` shall be used as the context created in `threadpool_create_work_item`. **]**
+**SRS_THREADPOOL_WIN32_05_002: [** Otherwise `context` shall be used as the context created in `threadpool_create_work_item`. **]**
 
-**S_R_S_THREADPOOL_WIN32_05_003: [** The `work_function` callback passed to `threadpool_create_work_item` shall be called with the `work_function_context` as an argument. `work_function_context` was set inside the `threadpool_create_work_item` as an argument to `CreateThreadpoolContext`. **]**
+**SRS_THREADPOOL_WIN32_05_003: [** The `work_function` callback passed to `threadpool_create_work_item` shall be called with the `work_function_context` as an argument. `work_function_context` was set inside the `threadpool_create_work_item` as an argument to `CreateThreadpoolContext`. **]**
 
 
 ### threadpool_timer_start
@@ -273,19 +273,19 @@ MOCKABLE_FUNCTION(, THREADPOOL_WORK_ITEM_HANDLE, threadpool_create_work_item, TH
 
 `threadpool_create_work_item` creates a work item to be executed by the threadpool.
 
-**S_R_S_THREADPOOL_WIN32_05_004: [** If `threadpool` is `NULL`, `threadpool_create_work_item` shall fail and return a `NULL` value. **]**
+**SRS_THREADPOOL_WIN32_05_004: [** If `threadpool` is `NULL`, `threadpool_create_work_item` shall fail and return a `NULL` value. **]**
 
-**S_R_S_THREADPOOL_WIN32_05_005: [** If `work_function` is `NULL`, `threadpool_create_work_item` shall fail and return a `NULL` value. **]**
+**SRS_THREADPOOL_WIN32_05_005: [** If `work_function` is `NULL`, `threadpool_create_work_item` shall fail and return a `NULL` value. **]**
 
-**S_R_S_THREADPOOL_WIN32_05_006: [** Otherwise `threadpool_create_work_item` shall allocate a context `work_item_context` of type `THREADPOOL_WORK_ITEM_HANDLE` where `work_function`, `work_function_context`, and `ptp_work` shall be saved. **]**
+**SRS_THREADPOOL_WIN32_05_006: [** Otherwise `threadpool_create_work_item` shall allocate a context `work_item_context` of type `THREADPOOL_WORK_ITEM_HANDLE` where `work_function`, `work_function_context`, and `ptp_work` shall be saved. **]**
 
-**S_R_S_THREADPOOL_WIN32_05_007: [** If any error occurs, `threadpool_create_work_item` shall fail and return a `NULL` value. **]**
+**SRS_THREADPOOL_WIN32_05_007: [** If any error occurs, `threadpool_create_work_item` shall fail and return a `NULL` value. **]**
 
-**S_R_S_THREADPOOL_WIN32_05_008: [** `threadpool_create_work_item` shall create `work_item_context` member variable `ptp_work` of type `PTP_WORK` by calling `CreateThreadpoolWork` to set the callback function as `on_work_callback_v2`. **]**
+**SRS_THREADPOOL_WIN32_05_008: [** `threadpool_create_work_item` shall create `work_item_context` member variable `ptp_work` of type `PTP_WORK` by calling `CreateThreadpoolWork` to set the callback function as `on_work_callback_v2`. **]**
 
-**S_R_S_THREADPOOL_WIN32_05_009: [** If there are no errors then this `work_item_context` of type `THREADPOOL_WORK_ITEM_HANDLE` would be returned indicating a succcess to the caller**]**
+**SRS_THREADPOOL_WIN32_05_009: [** If there are no errors then this `work_item_context` of type `THREADPOOL_WORK_ITEM_HANDLE` would be returned indicating a succcess to the caller. **]**
 
-**S_R_S_THREADPOOL_WIN32_05_010: [** If any error occurs, `threadpool_create_work_item` shall fail, free the newly created context and return a `NULL` value. **]**
+**SRS_THREADPOOL_WIN32_05_010: [** If any error occurs, `threadpool_create_work_item` shall fail, free the newly created context and return a `NULL` value. **]**
 
 
 ### threadpool_schedule_work_item
@@ -296,22 +296,24 @@ MOCKABLE_FUNCTION(, int, threadpool_schedule_work_item, THANDLE(THREADPOOL), thr
 
 `threadpool_schedule_work_item` schedules a work item to be executed by the threadpool.
 
-**S_R_S_THREADPOOL_WIN32_05_011: [** If `threadpool` is NULL, `threadpool_schedule_work_item` shall fail and return a `non-zero` value. **]**
+**SRS_THREADPOOL_WIN32_05_011: [** If `threadpool` is NULL, `threadpool_schedule_work_item` shall fail and return a `non-zero` value. **]**
 
-**S_R_S_THREADPOOL_WIN32_05_012: [** If `work_item_context` is NULL, `threadpool_schedule_work_item` shall fail and return a `non-zero` value. **]**
+**SRS_THREADPOOL_WIN32_05_012: [** If `work_item_context` is NULL, `threadpool_schedule_work_item` shall fail and return a `non-zero` value. **]**
 
-**S_R_S_THREADPOOL_WIN32_05_013: [** `threadpool_schedule_work_item` shall call `SubmitThreadpoolWork` to submit the work item for execution. **]**
+**SRS_THREADPOOL_WIN32_05_013: [** `threadpool_schedule_work_item` shall call `SubmitThreadpoolWork` to submit the work item for execution. **]**
 
 ### threadpool_destroy_work_item
 
 ```c
-MOCKABLE_FUNCTION(, void, threadpool_destroy_work_item, THREADPOOL_WORK_ITEM_HANDLE, work_item_context);
+MOCKABLE_FUNCTION(, void, threadpool_destroy_work_item, THANDLE(THREADPOOL), threadpool, THREADPOOL_WORK_ITEM_HANDLE, work_item_context);
 ```
 
 `threadpool_destroy_work_item` closes the `ptp_work` member variable in `work_item_context`and then frees the `work_item_context`
 
-**S_R_S_THREADPOOL_WIN32_05_014: [** If `work_item_context` is `NULL`, `threadpool_destroy_work_item` shall fail and not do anything before returning. **]**
+**SRS_THREADPOOL_WIN32_05_014: [ ** If `threadpool` is `NULL`, `threadpool_destroy_work_item` shall fail and return a `non-zero` value. **]**
 
-**S_R_S_THREADPOOL_WIN32_05_015: [** `threadpool_destroy_work_item` shall call `CloseThreadpoolWork` to close `ptp_work`. **]**
+**SRS_THREADPOOL_WIN32_05_015: [** If `work_item_context` is `NULL`, `threadpool_destroy_work_item` shall fail and not do anything before returning. **]**
 
-**S_R_S_THREADPOOL_WIN32_05_016: [** `threadpool_destroy_work_item` shall free the `work_item_context`. **]**
+**SRS_THREADPOOL_WIN32_05_016: [** `threadpool_destroy_work_item` shall call `CloseThreadpoolWork` to close `ptp_work`. **]**
+
+**SRS_THREADPOOL_WIN32_05_017: [** `threadpool_destroy_work_item` shall free the `work_item_context`. **]**

--- a/win32/devdoc/threadpool_win32.md
+++ b/win32/devdoc/threadpool_win32.md
@@ -170,7 +170,7 @@ static VOID CALLBACK on_work_callback_v2(PTP_CALLBACK_INSTANCE instance, void* c
 
 `on_work_callback_v2` executes the work function passed to `threadpool_create_work_item`.
 
-**SRS_THREADPOOL_WIN32_05_001: [** If `context` is `NULL`, `on_work_callback_v2` shall return. **]**
+**SRS_THREADPOOL_WIN32_05_001: [** If `context` is `NULL`, `on_work_callback_v2` shall Log Message with severity `CRITICAL` and `terminate`. **]**
 
 **SRS_THREADPOOL_WIN32_05_002: [** Otherwise `context` shall be used as the context created in `threadpool_create_work_item`. **]**
 

--- a/win32/reals/real_threadpool.h
+++ b/win32/reals/real_threadpool.h
@@ -41,7 +41,7 @@ extern "C" {
 
     int real_threadpool_schedule_work_item(THANDLE(THREADPOOL) threadpool, THREADPOOL_WORK_ITEM_HANDLE work_item_context);
 
-    void real_threadpool_destroy_work_item(THREADPOOL_WORK_ITEM_HANDLE work_item_context);
+    void real_threadpool_destroy_work_item(THANDLE(THREADPOOL) threadpool, THREADPOOL_WORK_ITEM_HANDLE work_item_context);
 
     int real_threadpool_schedule_work(THANDLE(THREADPOOL) threadpool, THREADPOOL_WORK_FUNCTION work_function, void* work_function_context);
 

--- a/win32/src/threadpool_win32.c
+++ b/win32/src/threadpool_win32.c
@@ -33,7 +33,7 @@ typedef struct THREADPOOL_WORK_ITEM_TAG
 {
     THREADPOOL_WORK_FUNCTION work_function;
     void* work_function_context;
-    PTP_WORK* ptp_work;
+    PTP_WORK ptp_work;
 } THREADPOOL_WORK_ITEM, *THREADPOOL_WORK_ITEM_HANDLE;
 
 typedef struct TIMER_INSTANCE_TAG
@@ -87,7 +87,19 @@ static VOID CALLBACK on_work_callback(PTP_CALLBACK_INSTANCE instance, PVOID cont
 
 static VOID CALLBACK on_work_callback_v2(PTP_CALLBACK_INSTANCE instance, PVOID context, PTP_WORK work)
 {
-    LogWarning("Printing %p %p %p", instance, context, work);
+    if (context == NULL)
+    {
+        /* Codes_SRS_THREADPOOL_WIN32_05_001: [ If context is NULL, on_work_callback_v2 shall return. ]*/
+        LogError("Invalid arguments: PTP_CALLBACK_INSTANCE instance=%p, PVOID context=%p, PTP_WORK work=%p",
+            instance, context, work);
+    }
+    else
+    {
+        /* Codes_SRS_THREADPOOL_WIN32_05_002: [ Otherwise context shall be used as the context created in threadpool_create_work_item. ]*/
+        THREADPOOL_WORK_ITEM_HANDLE work_item_context = (THREADPOOL_WORK_ITEM_HANDLE)context;
+        /* Codes_SRS_THREADPOOL_WIN32_05_003: [ The work_function callback passed to threadpool_create_work_item shall be called with the work_function_context as an argument. work_function_context was set inside the threadpool_create_work_item as an argument to CreateThreadpoolContext. ]*/
+        work_item_context->work_function(work_item_context->work_function_context);
+    }
 }
 
 static void internal_close(THREADPOOL* threadpool)
@@ -277,24 +289,133 @@ void threadpool_close(THANDLE(THREADPOOL) threadpool)
     }
 }
 
-THREADPOOL_WORK_ITEM_HANDLE threadpool_create_work_item(THANDLE(THREADPOOL) threadpool, THREADPOOL_WORK_FUNCTION work_function, void* work_function_context)
+THREADPOOL_WORK_ITEM_HANDLE threadpool_create_work_item(THANDLE(THREADPOOL) threadpool, THREADPOOL_WORK_FUNCTION work_function, PVOID work_function_context)
 {
-    (void*)threadpool;
-    (void*)work_function;
-    (void*)work_function_context;
-    return NULL;
+    THREADPOOL_WORK_ITEM_HANDLE work_item_context = NULL;
+
+    /* Codes_SRS_THREADPOOL_WIN32_01_022: [ work_function_context shall be allowed to be NULL. ]*/
+
+    if (
+        /* Codes_SRS_THREADPOOL_WIN32_05_004: [ If threadpool is NULL, threadpool_create_work_item shall fail and return a NULL value. ]*/
+        (threadpool == NULL) ||
+        /* Codes_SRS_THREADPOOL_WIN32_05_005: [ If work_function is NULL, threadpool_create_work_item shall fail and return a NULL value. ]*/
+        (work_function == NULL)
+        )
+    {
+        LogError("Invalid arguments: THANDLE(THREADPOOL) threadpool=%p, THREADPOOL_WORK_FUNCTION work_function=%p, void* work_function_context=%p",
+            threadpool, work_function, work_function_context);
+    }
+    else
+    {
+        THREADPOOL* threadpool_ptr = THANDLE_GET_T(THREADPOOL)(threadpool);
+
+        (void)InterlockedIncrement(&threadpool_ptr->pending_api_calls);
+
+        THREADPOOL_WIN32_STATE state = InterlockedAdd(&threadpool_ptr->state, 0);
+        if (state != (LONG)THREADPOOL_WIN32_STATE_OPEN)
+        {
+            LogWarning("Bad state: %" PRI_MU_ENUM, MU_ENUM_VALUE(THREADPOOL_WIN32_STATE, state));
+        }
+        else
+        {
+            /* Codes_SRS_THREADPOOL_WIN32_05_006: [ Otherwise threadpool_create_work_item shall allocate a context work_item_context of type THREADPOOL_WORK_ITEM_HANDLE where work_function, work_function_context, and ptp_work shall be saved. ]*/
+            work_item_context = malloc(sizeof(THREADPOOL_WORK_ITEM));
+            if (work_item_context == NULL)
+            {
+                /* Codes_SRS_THREADPOOL_WIN32_05_007: [ If any error occurs, threadpool_create_work_item shall fail and return a NULL value. ]*/
+                LogError("malloc failed");
+            }
+            else
+            {
+                work_item_context->work_function = work_function;
+                work_item_context->work_function_context = work_function_context;
+
+                /* Codes_SRS_THREADPOOL_WIN32_05_008: [ threadpool_create_work_item shall create work_item_context member variable ptp_work of type PTP_WORK by calling CreateThreadpoolWork to set the callback function as on_work_callback_v2. ]*/
+                work_item_context->ptp_work = CreateThreadpoolWork(on_work_callback_v2, work_item_context, &threadpool_ptr->tp_environment);
+                /* Codes_SRS_THREADPOOL_WIN32_05_009: [ If there are no errors then this work_item_context of type THREADPOOL_WORK_ITEM_HANDLE would be returned indicating a succcess to the caller. ]*/
+                if (work_item_context->ptp_work == NULL)
+                {
+                    /* Codes_SRS_THREADPOOL_WIN32_05_010: [ If any error occurs, threadpool_create_work_item shall fail, free the newly created context and return a NULL value. ]*/
+                    LogError("CreateThreadpoolWork failed");
+                    free(work_item_context);
+                    work_item_context = NULL;
+                }
+            }
+        }
+        (void)InterlockedDecrement(&threadpool_ptr->pending_api_calls);
+        WakeByAddressSingle((PVOID)&threadpool_ptr->pending_api_calls);
+    }
+    return work_item_context;
 }
 
 int threadpool_schedule_work_item(THANDLE(THREADPOOL) threadpool, THREADPOOL_WORK_ITEM_HANDLE work_item_context)
 {
-    (void*)threadpool;
-    (void*)work_item_context;
-    return 0;
+    int result = MU_FAILURE;
+
+    if (
+        /* Codes_SRS_THREADPOOL_WIN32_05_011: [ If threadpool is NULL, threadpool_schedule_work_item shall fail and return a non-zero value. ]*/
+        (threadpool == NULL) ||
+        /* Codes_SRS_THREADPOOL_WIN32_05_012: [ If work_item_context is NULL, threadpool_schedule_work_item shall fail and return a non-zero value. ]*/
+        (work_item_context == NULL)
+        )
+    {
+        LogError("Invalid arguments: THANDLE(THREADPOOL) threadpool=%p", threadpool);
+    }
+    else
+    {
+        THREADPOOL* threadpool_ptr = THANDLE_GET_T(THREADPOOL)(threadpool);
+
+        (void)InterlockedIncrement(&threadpool_ptr->pending_api_calls);
+
+        THREADPOOL_WIN32_STATE state = InterlockedAdd(&threadpool_ptr->state, 0);
+        if (state != (LONG)THREADPOOL_WIN32_STATE_OPEN)
+        {
+            LogWarning("Bad state: %" PRI_MU_ENUM, MU_ENUM_VALUE(THREADPOOL_WIN32_STATE, state));
+        }
+        else
+        {
+            /* Codes_SRS_THREADPOOL_WIN32_05_013: [ threadpool_schedule_work_item shall call SubmitThreadpoolWork to submit the work item for execution. ]*/
+            SubmitThreadpoolWork(work_item_context->ptp_work);
+            result = 0;
+        }
+        (void)InterlockedDecrement(&threadpool_ptr->pending_api_calls);
+        WakeByAddressSingle((PVOID)&threadpool_ptr->pending_api_calls);
+    }
+    return result;
 }
 
-void threadpool_destroy_work_item(THREADPOOL_WORK_ITEM_HANDLE work_item_context)
+void threadpool_destroy_work_item(THANDLE(THREADPOOL) threadpool, THREADPOOL_WORK_ITEM_HANDLE work_item_context)
 {
-    (void*)work_item_context;
+    if (
+        /* Codes_SRS_THREADPOOL_WIN32_05_014: [ If threadpool is NULL, threadpool_destroy_work_item shall fail and return a non-zero value. ]*/
+        (threadpool == NULL) ||
+        /* Codes_SRS_THREADPOOL_WIN32_05_015: [ If work_item_context is NULL, threadpool_destroy_work_item shall fail and not do anything before returning. ]*/
+        (work_item_context == NULL)
+        )
+    {
+        LogError("Invalid arguments: Work Item Context is NULL.");
+    }
+    else
+    {
+        THREADPOOL* threadpool_ptr = THANDLE_GET_T(THREADPOOL)(threadpool);
+
+        (void)InterlockedIncrement(&threadpool_ptr->pending_api_calls);
+
+        THREADPOOL_WIN32_STATE state = InterlockedAdd(&threadpool_ptr->state, 0);
+        if (state != (LONG)THREADPOOL_WIN32_STATE_OPEN)
+        {
+            LogWarning("Bad state: %" PRI_MU_ENUM, MU_ENUM_VALUE(THREADPOOL_WIN32_STATE, state));
+        }
+        else
+        {
+            /* Codes_SRS_THREADPOOL_WIN32_05_016: [ threadpool_destroy_work_item shall call CloseThreadpoolWork to close ptp_work. ]*/
+            CloseThreadpoolWork(work_item_context->ptp_work);
+        }
+        (void)InterlockedDecrement(&threadpool_ptr->pending_api_calls);
+        WakeByAddressSingle((PVOID)&threadpool_ptr->pending_api_calls);
+        /* Codes_SRS_THREADPOOL_WIN32_05_017: [ threadpool_destroy_work_item shall free the work_item_context. ]*/
+        free(work_item_context);
+    }
 }
 
 int threadpool_schedule_work(THANDLE(THREADPOOL) threadpool, THREADPOOL_WORK_FUNCTION work_function, void* work_function_context)

--- a/win32/src/threadpool_win32.c
+++ b/win32/src/threadpool_win32.c
@@ -11,6 +11,7 @@
 #include "c_pal/execution_engine_win32.h"
 #include "c_pal/gballoc_hl.h"
 #include "c_pal/gballoc_hl_redirect.h"
+#include "c_pal/log_critical_and_terminate.h"
 #include "c_pal/thandle.h"
 #include "c_pal/threadpool.h"
 
@@ -89,8 +90,8 @@ static VOID CALLBACK on_work_callback_v2(PTP_CALLBACK_INSTANCE instance, PVOID c
 {
     if (context == NULL)
     {
-        /* Codes_SRS_THREADPOOL_WIN32_05_001: [ If context is NULL, on_work_callback_v2 shall return. ]*/
-        LogError("Invalid arguments: PTP_CALLBACK_INSTANCE instance=%p, PVOID context=%p, PTP_WORK work=%p",
+        /* Codes_SRS_THREADPOOL_WIN32_05_001: [ If context is NULL, on_work_callback_v2 shall Log Message with severity CRITICAL and terminate. ]*/
+        LogCriticalAndTerminate("Invalid arguments: PTP_CALLBACK_INSTANCE instance=%p, PVOID context=%p, PTP_WORK work=%p",
             instance, context, work);
     }
     else
@@ -312,7 +313,7 @@ THREADPOOL_WORK_ITEM_HANDLE threadpool_create_work_item(THANDLE(THREADPOOL) thre
         (void)InterlockedIncrement(&threadpool_ptr->pending_api_calls);
 
         THREADPOOL_WIN32_STATE state = InterlockedAdd(&threadpool_ptr->state, 0);
-        if (state != (LONG)THREADPOOL_WIN32_STATE_OPEN)
+        if (state != THREADPOOL_WIN32_STATE_OPEN)
         {
             LogWarning("Bad state: %" PRI_MU_ENUM, MU_ENUM_VALUE(THREADPOOL_WIN32_STATE, state));
         }
@@ -368,7 +369,7 @@ int threadpool_schedule_work_item(THANDLE(THREADPOOL) threadpool, THREADPOOL_WOR
         (void)InterlockedIncrement(&threadpool_ptr->pending_api_calls);
 
         THREADPOOL_WIN32_STATE state = InterlockedAdd(&threadpool_ptr->state, 0);
-        if (state != (LONG)THREADPOOL_WIN32_STATE_OPEN)
+        if (state != THREADPOOL_WIN32_STATE_OPEN)
         {
             LogWarning("Bad state: %" PRI_MU_ENUM, MU_ENUM_VALUE(THREADPOOL_WIN32_STATE, state));
         }
@@ -402,7 +403,7 @@ void threadpool_destroy_work_item(THANDLE(THREADPOOL) threadpool, THREADPOOL_WOR
         (void)InterlockedIncrement(&threadpool_ptr->pending_api_calls);
 
         THREADPOOL_WIN32_STATE state = InterlockedAdd(&threadpool_ptr->state, 0);
-        if (state != (LONG)THREADPOOL_WIN32_STATE_OPEN)
+        if (state != THREADPOOL_WIN32_STATE_OPEN)
         {
             LogWarning("Bad state: %" PRI_MU_ENUM, MU_ENUM_VALUE(THREADPOOL_WIN32_STATE, state));
         }
@@ -442,7 +443,7 @@ int threadpool_schedule_work(THANDLE(THREADPOOL) threadpool, THREADPOOL_WORK_FUN
         (void)InterlockedIncrement(&threadpool_ptr->pending_api_calls);
 
         THREADPOOL_WIN32_STATE state = InterlockedAdd(&threadpool_ptr->state, 0);
-        if (state != (LONG)THREADPOOL_WIN32_STATE_OPEN)
+        if (state != THREADPOOL_WIN32_STATE_OPEN)
         {
             LogWarning("Bad state: %" PRI_MU_ENUM, MU_ENUM_VALUE(THREADPOOL_WIN32_STATE, state));
             result = MU_FAILURE;
@@ -554,7 +555,7 @@ int threadpool_timer_start(THANDLE(THREADPOOL) threadpool, uint32_t start_delay_
         (void)InterlockedIncrement(&threadpool_ptr->pending_api_calls);
 
         THREADPOOL_WIN32_STATE state = InterlockedAdd(&threadpool_ptr->state, 0);
-        if (state != (LONG)THREADPOOL_WIN32_STATE_OPEN)
+        if (state != THREADPOOL_WIN32_STATE_OPEN)
         {
             LogWarning("Bad state: %" PRI_MU_ENUM, MU_ENUM_VALUE(THREADPOOL_WIN32_STATE, state));
             result = MU_FAILURE;

--- a/win32/tests/threadpool_win32_ut/threadpool_win32_ut.c
+++ b/win32/tests/threadpool_win32_ut/threadpool_win32_ut.c
@@ -24,6 +24,7 @@
 #include "c_pal/execution_engine.h"
 #include "c_pal/execution_engine_win32.h"
 #include "c_pal/interlocked.h"
+#include "c_pal/ps_util.h"
 
 #undef ENABLE_MOCKS
 
@@ -1309,7 +1310,7 @@ TEST_FUNCTION(on_timer_callback_calls_user_callback_multiple_times_as_timer_fire
 
 /* on_work_callback_v2 */
 
-/* Tests_SRS_THREADPOOL_WIN32_05_001: [ If context is NULL, on_work_callback_v2 shall return. ]*/
+/* Tests_SRS_THREADPOOL_WIN32_05_001: [ If context is NULL, on_work_callback_v2 shall Log Message with severity CRITICAL and terminate. ]*/
 TEST_FUNCTION(on_work_callback_v2_with_NULL_context_returns)
 {
     // arrange
@@ -1335,6 +1336,8 @@ TEST_FUNCTION(on_work_callback_v2_with_NULL_context_returns)
     ASSERT_ARE_EQUAL(void_ptr, return_work_item_context, test_work_item_context);
 
     umock_c_reset_all_calls();
+
+    STRICT_EXPECTED_CALL(ps_util_terminate_process());
 
     // act
     test_work_callback_v2(NULL, NULL, ptp_work);


### PR DESCRIPTION
Threadpool changes on WIN32 for splitting the threadpool_schedule_work into threadpool_create_work_item, threadpool_schedule_work_item, and threadpool_destroy_work_item.