### PR TITLE
Fix to helgrind error for accessing pending_work_item_count_ptr

### DIFF
--- a/linux/devdoc/threadpool_linux_requirements.md
+++ b/linux/devdoc/threadpool_linux_requirements.md
@@ -237,7 +237,7 @@ MOCKABLE_FUNCTION(, int, threadpool_schedule_work, THANDLE(THREADPOOL), threadpo
 
 **SRS_THREADPOOL_LINUX_07_048: [** If reallocating the task array fails, `threadpool_schedule_work` shall fail and return a non-zero value. **]**
 
-**SRS_THREADPOOL_LINUX_07_049: [** `threadpool_schedule_work` shall initialize `pending_work_item_count_ptr` with `NULL` then copy the work function and work function context into insert position in the task array and assign `0` to the return variable to indicate success. **]**
+**SRS_THREADPOOL_LINUX_07_049: [** `threadpool_schedule_work` shall copy the work function and work function context into insert position in the task array and assign `0` to the return variable to indicate success. **]**
 
 **SRS_THREADPOOL_LINUX_07_050: [** `threadpool_schedule_work` shall set the `task_state` to `TASK_WAITING` and then release the shared SRW lock. **]**
 

--- a/linux/src/threadpool_linux.c
+++ b/linux/src/threadpool_linux.c
@@ -587,13 +587,14 @@ int threadpool_schedule_work(THANDLE(THREADPOOL) threadpool, THREADPOOL_WORK_FUN
                     }
                     continue;
                 }
-                /* Codes_SRS_THREADPOOL_LINUX_07_049: [ threadpool_schedule_work shall initialize pending_work_item_count_ptr with NULL then copy the work function and work function context into insert position in the task array and assign 0 to the return variable to indicate success. ] */
+                /* Codes_SRS_THREADPOOL_LINUX_07_049: [ threadpool_schedule_work shall copy the work function and work function context into insert position in the task array and assign 0 to the return variable to indicate success. ] */
                 else
                 {
                     THREADPOOL_TASK* task_item = &threadpool_ptr->task_array[insert_pos];
                     task_item->work_function_ctx = work_function_ctx;
                     task_item->work_function = work_function;
-                    task_item->pending_work_item_count_ptr = NULL;
+                    // Assignment of task_item->pending_work_item_count_ptr to NULL is not needed here since pending_work_item_count_ptr is initialized to NULL in threadpool_create
+                    // and the initialization of task_item->pending_work_item_count_ptr to NULL in reallocate_threadpool_array is protected by exclusive lock
 
                     /* Codes_SRS_THREADPOOL_LINUX_07_050: [ threadpool_schedule_work shall set the task_state to TASK_WAITING and then release the shared SRW lock. ] */
                     (void)interlocked_exchange(&task_item->task_state, TASK_WAITING);

--- a/linux/tests/threadpool_linux_ut/threadpool_linux_ut.c
+++ b/linux/tests/threadpool_linux_ut/threadpool_linux_ut.c
@@ -835,7 +835,7 @@ TEST_FUNCTION(threadpool_schedule_work_with_NULL_work_function_fails)
 /* Tests_SRS_THREADPOOL_LINUX_07_033: [ threadpool_schedule_work shall acquire the SRW lock in shared mode by calling srw_lock_acquire_shared. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_034: [ threadpool_schedule_work shall increment the insert_pos. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_035: [ If task state is TASK_NOT_USED, threadpool_schedule_work shall set the current task state to TASK_INITIALIZING. ]*/
-/* Tests_SRS_THREADPOOL_LINUX_07_049: [ threadpool_schedule_work shall initialize pending_work_item_count_ptr with NULL then copy the work function and work function context into insert position in the task array and assign `0` to the return variable to indicate success. ]*/
+/* Tests_SRS_THREADPOOL_LINUX_07_049: [ threadpool_schedule_work shall copy the work function and work function context into insert position in the task array and assign `0` to the return variable to indicate success. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_050: [ threadpool_schedule_work shall set the task_state to TASK_WAITING and then release the shared SRW lock. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_051: [ threadpool_schedule_work shall unblock the threadpool semaphore by calling sem_post. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_047: [ threadpool_schedule_work shall return zero on success. ]*/
@@ -864,7 +864,7 @@ TEST_FUNCTION(threadpool_schedule_work_succeeds)
 /* Tests_SRS_THREADPOOL_LINUX_07_033: [ threadpool_schedule_work shall acquire the SRW lock in shared mode by calling srw_lock_acquire_shared. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_034: [ threadpool_schedule_work shall increment the insert_pos. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_035: [ If task state is TASK_NOT_USED, threadpool_schedule_work shall set the current task state to TASK_INITIALIZING. ]*/
-/* Tests_SRS_THREADPOOL_LINUX_07_049: [ threadpool_schedule_work shall initialize pending_work_item_count_ptr with NULL then copy the work function and work function context into insert position in the task array and assign `0` to the return variable to indicate success. ]*/
+/* Tests_SRS_THREADPOOL_LINUX_07_049: [ threadpool_schedule_work shall copy the work function and work function context into insert position in the task array and assign `0` to the return variable to indicate success. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_050: [ threadpool_schedule_work shall set the task_state to TASK_WAITING and then release the shared SRW lock. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_051: [ threadpool_schedule_work shall unblock the threadpool semaphore by calling sem_post. ]*/
 /* Tests_SRS_THREADPOOL_LINUX_07_047: [ threadpool_schedule_work shall return zero on success. ]*/


### PR DESCRIPTION
The pending_work_item_count_ptr is not used when threadpool_schedule_work is used. pending_work_item_count_ptr is always initialized to NULL in threadpool_create and when pending_work_item_count_ptr is initialized to NULL in reallocate task array, an exlusive lock is used. So, removing the NULL assignment in the threadpool_schedule_work.