### PR TITLE
added GBALLOC_LL_TYPE_{ALLOCATOR_TYPE} definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(GBALLOC_LL_TYPE_VALUES PASSTHROUGH WIN32HEAP MIMALLOC JEMALLOC) #the list of
 set(GBALLOC_LL_TYPE PASSTHROUGH CACHE STRING "Value of GBALLOC_LL_TYPE") #setting the property's default value in case none is taken from the command line
 set_property(CACHE GBALLOC_LL_TYPE PROPERTY STRINGS ${GBALLOC_LL_TYPE_VALUES}) #build a property that can have only the allowed values
 
+
 list(FIND GBALLOC_LL_TYPE_VALUES ${GBALLOC_LL_TYPE} index) #check that the received value (either the default or the one from command line) matches one of the allowed values.
 if(index EQUAL -1)
     message(FATAL_ERROR "GBALLOC_LL_TYPE must be one of '${GBALLOC_LL_TYPE_VALUES}'. It was actually '${GBALLOC_LL_TYPE}'")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,4 +234,5 @@ include(CMakePackageConfigHelpers)
 #Insert vld in all executables if so required
 add_vld_if_defined(${CMAKE_CURRENT_SOURCE_DIR})
 
+# Define GBALLOC_LL_TYPE_<ALLOCATOR_TYPE> for the c_pal target
 target_compile_definitions(c_pal INTERFACE GBALLOC_LL_TYPE_${GBALLOC_LL_TYPE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,11 +57,12 @@ set(GBALLOC_LL_TYPE_VALUES PASSTHROUGH WIN32HEAP MIMALLOC JEMALLOC) #the list of
 set(GBALLOC_LL_TYPE PASSTHROUGH CACHE STRING "Value of GBALLOC_LL_TYPE") #setting the property's default value in case none is taken from the command line
 set_property(CACHE GBALLOC_LL_TYPE PROPERTY STRINGS ${GBALLOC_LL_TYPE_VALUES}) #build a property that can have only the allowed values
 
-
 list(FIND GBALLOC_LL_TYPE_VALUES ${GBALLOC_LL_TYPE} index) #check that the received value (either the default or the one from command line) matches one of the allowed values.
 if(index EQUAL -1)
     message(FATAL_ERROR "GBALLOC_LL_TYPE must be one of '${GBALLOC_LL_TYPE_VALUES}'. It was actually '${GBALLOC_LL_TYPE}'")
 endif()
+
+# target_compile_definitions(c_pal INTERFACE GBALLOC_LL_TYPE_${GBALLOC_LL_TYPE})
 
 #canon way of limiting an option to a predefined set of values
 set(GBALLOC_HL_TYPE_VALUES PASSTHROUGH METRICS) #the list of values which are allowed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,6 @@ if(index EQUAL -1)
     message(FATAL_ERROR "GBALLOC_LL_TYPE must be one of '${GBALLOC_LL_TYPE_VALUES}'. It was actually '${GBALLOC_LL_TYPE}'")
 endif()
 
-# target_compile_definitions(c_pal INTERFACE GBALLOC_LL_TYPE_${GBALLOC_LL_TYPE})
-
 #canon way of limiting an option to a predefined set of values
 set(GBALLOC_HL_TYPE_VALUES PASSTHROUGH METRICS) #the list of values which are allowed
 set(GBALLOC_HL_TYPE PASSTHROUGH CACHE STRING "Value of GBALLOC_HL_TYPE") #build a property that can have only the allowed values
@@ -235,3 +233,5 @@ include(CMakePackageConfigHelpers)
 
 #Insert vld in all executables if so required
 add_vld_if_defined(${CMAKE_CURRENT_SOURCE_DIR})
+
+target_compile_definitions(c_pal INTERFACE GBALLOC_LL_TYPE_${GBALLOC_LL_TYPE})


### PR DESCRIPTION
added definition for GBALLOC_LL_TYPE_{ALLOCATOR_TYPE} in CMakeLists.txt that will be used in main.cpp to decide if we should enable jemalloc specific logic or not.