### PR TITLE
Remove lazy_init from gballoc_hl_passthrough

### DIFF
--- a/linux/src/gballoc_hl_passthrough.c
+++ b/linux/src/gballoc_hl_passthrough.c
@@ -16,9 +16,7 @@ int gballoc_hl_init(void* gballoc_hl_init_params, void* gballoc_ll_init_params)
     (void)gballoc_hl_init_params; /*are ignored, this is "passthrough*/
 
     /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_42_001: [ gballoc_hl_init shall call gballoc_ll_init as function to execute and gballoc_ll_init_params as parameter and return the result. ]*/
-    int result = gballoc_ll_init(gballoc_ll_init_params);
-
-    return result;
+    return gballoc_ll_init(gballoc_ll_init_params);
 }
 
 void gballoc_hl_deinit(void)
@@ -71,12 +69,8 @@ void gballoc_hl_free(void* ptr)
 
 size_t gballoc_hl_size(void* ptr)
 {
-    size_t result;
-
     /* Codes_SRS_GBALLOC_HL_PASSTHROUGH_01_003: [ Otherwise, gballoc_hl_size shall call gballoc_ll_size with ptr as argument and return the result of gballoc_ll_size. ]*/
-    result = gballoc_ll_size(ptr);
-
-    return result;
+    return gballoc_ll_size(ptr);
 }
 
 void* gballoc_hl_calloc(size_t nmemb, size_t size)

--- a/linux/src/gballoc_hl_passthrough.c
+++ b/linux/src/gballoc_hl_passthrough.c
@@ -11,27 +11,12 @@
 
 #include "c_pal/gballoc_hl.h"
 
-static int wasInitialized = 0;
-
 int gballoc_hl_init(void* gballoc_hl_init_params, void* gballoc_ll_init_params)
 {
-    int result;
     (void)gballoc_hl_init_params; /*are ignored, this is "passthrough*/
 
-    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_018: [ do_init shall call gballoc_ll_init(params). ]*/
-
-    if (gballoc_ll_init(gballoc_ll_init_params) != 0)
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_003: [ If there are any failures then gballoc_hl_init shall fail and return a non-zero value. ]*/
-        LogError("failure in gballoc_ll_init(gballoc_ll_init_params=%p)", gballoc_ll_init_params);
-        result = MU_FAILURE;
-    }
-    else
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_002: [ gballoc_hl_init shall succeed and return 0. ]*/
-        result = 0;
-        wasInitialized = 1;
-    }
+    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_42_001: [ gballoc_hl_init shall call gballoc_ll_init as function to execute and gballoc_ll_init_params as parameter and return the result. ]*/
+    int result = gballoc_ll_init(gballoc_ll_init_params);
 
     return result;
 }
@@ -39,11 +24,7 @@ int gballoc_hl_init(void* gballoc_hl_init_params, void* gballoc_ll_init_params)
 void gballoc_hl_deinit(void)
 {
     /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_004: [ gballoc_hl_deinit shall call gballoc_ll_deinit. ]*/
-    if (wasInitialized)
-    {
-        gballoc_ll_deinit();
-        wasInitialized = 0;
-    }
+    gballoc_ll_deinit();
 }
 
 void* gballoc_hl_malloc(size_t size)
@@ -235,4 +216,3 @@ int gballoc_hl_set_option(const char* option_name, void* option_value)
     /* Codes_SRS_GBALLOC_HL_PASSTHROUGH_28_001: [ gballoc_hl_set_option shall call gballoc_ll_set_option with option_name and option_value as arguments. ]*/
     return gballoc_ll_set_option(option_name, option_value);
 }
- 

--- a/linux/src/gballoc_hl_passthrough.c
+++ b/linux/src/gballoc_hl_passthrough.c
@@ -73,16 +73,9 @@ size_t gballoc_hl_size(void* ptr)
 {
     size_t result;
 
-    if (!wasInitialized)
-    {
-        /* Codes_SRS_GBALLOC_HL_PASSTHROUGH_01_002: [ If the module was not initialized, gballoc_hl_size shall return 0. ]*/
-        result = 0;
-    }
-    else
-    {
-        /* Codes_SRS_GBALLOC_HL_PASSTHROUGH_01_003: [ Otherwise, gballoc_hl_size shall call gballoc_ll_size with ptr as argument and return the result of gballoc_ll_size. ]*/
-        result = gballoc_ll_size(ptr);
-    }
+    /* Codes_SRS_GBALLOC_HL_PASSTHROUGH_01_003: [ Otherwise, gballoc_hl_size shall call gballoc_ll_size with ptr as argument and return the result of gballoc_ll_size. ]*/
+    result = gballoc_ll_size(ptr);
+
     return result;
 }
 

--- a/linux/tests/gballoc_hl_passthrough_ut/gballoc_hl_passthrough_ut.c
+++ b/linux/tests/gballoc_hl_passthrough_ut/gballoc_hl_passthrough_ut.c
@@ -77,8 +77,7 @@ TEST_FUNCTION_CLEANUP(TestMethodCleanup)
 {
 }
 
-/*Tests_SRS_GBALLOC_HL_PASSTHROUGH_02_018: [ do_init shall call gballoc_ll_init(params). ]*/
-/*Tests_SRS_GBALLOC_HL_PASSTHROUGH_02_002: [ gballoc_hl_init shall succeed and return 0. ]*/
+/*Tests_SRS_GBALLOC_HL_PASSTHROUGH_42_001: [ gballoc_hl_init shall call gballoc_ll_init as function to execute and gballoc_ll_init_params as parameter and return the result. ]*/
 TEST_FUNCTION(gballoc_hl_init_happy_path)
 {
     ///arrange
@@ -98,7 +97,7 @@ TEST_FUNCTION(gballoc_hl_init_happy_path)
     gballoc_hl_deinit();
 }
 
-/*Tests_SRS_GBALLOC_HL_PASSTHROUGH_02_003: [ If there are any failures then gballoc_hl_init shall fail and return a non-zero value. ]*/
+/*Tests_SRS_GBALLOC_HL_PASSTHROUGH_42_001: [ gballoc_hl_init shall call gballoc_ll_init as function to execute and gballoc_ll_init_params as parameter and return the result. ]*/
 TEST_FUNCTION(gballoc_hl_init_unhappy_path)
 {
     ///arrange
@@ -116,15 +115,15 @@ TEST_FUNCTION(gballoc_hl_init_unhappy_path)
 }
 
 /*Tests_SRS_GBALLOC_HL_PASSTHROUGH_02_004: [ gballoc_hl_deinit shall call gballoc_ll_deinit. ]*/
-TEST_FUNCTION(gballoc_hl_deinit_does_nothing_when_not_init)
+TEST_FUNCTION(gballoc_hl_deinit_calls_ll_deinit)
 {
     ///arrange
     int result;
-    STRICT_EXPECTED_CALL(gballoc_ll_init((void*)0x33))
-        .SetReturn(MU_FAILURE);
     result = gballoc_hl_init(NULL, (void*)0x33);
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, 0, result);
     umock_c_reset_all_calls();
+
+    STRICT_EXPECTED_CALL(gballoc_ll_deinit());
 
     ///act
     gballoc_hl_deinit();
@@ -431,27 +430,6 @@ TEST_FUNCTION(gballoc_hl_get_free_latency_buckets_zeroes)
 }
 
 /* gballoc_hl_size */
-
-/* Tests_SRS_GBALLOC_HL_PASSTHROUGH_01_002: [ If the module was not initialized, gballoc_hl_size shall return 0. ]*/
-TEST_FUNCTION(when_module_is_not_initialized_gballoc_hl_size_fails_and_returns_0)
-{
-    ///arrange
-    ASSERT_ARE_EQUAL(int, 0, gballoc_ll_init(NULL));
-    void* ptr = gballoc_ll_malloc(3);
-    ASSERT_IS_NOT_NULL(ptr);
-    gballoc_ll_deinit();
-    umock_c_reset_all_calls();
-
-    ///act
-    size_t size = gballoc_hl_size(ptr);
-
-    ///assert
-    ASSERT_ARE_EQUAL(size_t, 0, size);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-
-    ///clean
-    gballoc_ll_free(ptr);
-}
 
 /* Tests_SRS_GBALLOC_HL_PASSTHROUGH_01_003: [ Otherwise, gballoc_hl_size shall call gballoc_ll_size with ptr as argument and return the result of gballoc_ll_size. ]*/
 TEST_FUNCTION(gballoc_hl_size_calls_the_underlying_gballoc_ll_size)

--- a/win32/devdoc/gballoc_design.md
+++ b/win32/devdoc/gballoc_design.md
@@ -3,15 +3,15 @@
 `gballoc` is a layer that abstracts memory allocators. The need to have and be able to compare multiple memory allocators stems from performance requirements. Not all memory allocators have the same performance and for the sake of being able to compare them gballoc exists.
 
 `gballoc` is divided in 2 layers (`ll` stands for `lower layer`, `hl` stands for `higher layer`):
-a) `gballoc_ll` - contains software wrappers over the memory allocation as provided by other components. For example, `gballoc_malloc/free` will redirect to `HeapAlloc/Free` when Windows APIs are directly used.
-b) `gballoc_hl` - contains performance measurements for `gballoc_ll` and it is build on top of `gballoc_ll`.
+a. `gballoc_ll` - contains software wrappers over the memory allocation as provided by other components. For example, `gballoc_malloc/free` will redirect to `HeapAlloc/Free` when Windows APIs are directly used.
+b. `gballoc_hl` - contains performance measurements for `gballoc_ll` and it is built on top of `gballoc_ll`.
 
 
-`gballoc_ll` consists of a header file (`gballoc_ll.h`) and several possible implementation of its functions (i.e.: `gballoc_ll_crt.c`, `gballoc_ll_win.c`, `gballoc_ll_mimalloc.c` etc).
+`gballoc_ll` consists of a header file (`gballoc_ll.h`) and several possible implementation of its functions (i.e.: `gballoc_ll_crt.c`, `gballoc_ll_win.c`, `gballoc_ll_mimalloc.c`, etc.)
 
-`gballoc_hl` consists of a header file (`gballoc_hl.h`) and several possible implementation of the performance functions(i.e. `gballoc_hl_passthrough.c`, `gballoc_hl_buckets.c` etc)
+`gballoc_hl` consists of a header file (`gballoc_hl.h`) and several possible implementation of the performance functions(i.e. `gballoc_hl_passthrough.c`, `gballoc_hl_buckets.c`, etc.)
 
-Both `gballoc_ll` and `gballoc_hl` have their own set of orthogonal configurations in CMake. That is - it is possible to use any combination of `gballoc_ll` implementation with any other implementation of `gballoc_ll`. 
+Both `gballoc_ll` and `gballoc_hl` have their own set of orthogonal configurations in CMake. That is - it is possible to use any combination of `gballoc_ll` implementation with any other implementation of `gballoc_ll`.
 
 As far as Windows is concerned there are several CMake options.
 
@@ -19,16 +19,18 @@ As far as Windows is concerned there are several CMake options.
 
   2. Once a heap type is used, there are other several CMakeLists switches that further influence the SW behavior.
 
-    a) `gballoc_ll` implementation is switched between its implementations by the CMake option `GBALLOC_LL_TYPE` (of type string) which can be either
+    a. `gballoc_ll` implementation is switched between its implementations by the CMake option `GBALLOC_LL_TYPE` (of type string) which can be either
 
       i. "PASSTHROUGH" - `gballoc_ll` shall route its calls directly to C's routines.
 
-      ii. "WIN32HEAP" - `gballoc_ll` shall route its calls directly to Windows routines 
+      ii. "WIN32HEAP" - `gballoc_ll` shall route its calls directly to Windows routines
         (`HeapAlloc`, `HeapReAlloc`, `HeapFree`)
 
       iii. "MIMALLOC" - `gballoc_ll` shall route its calls directly to `mimalloc` APIs.
 
-    b) `gballoc_hl` implementation is governed by `GBALLOC_HL_TYPE` (of type string) which can be either:
+      iv. "JEMALLOC" - `gballoc_ll` shall route its calls directly to `jemalloc` APIs.
+
+    b. `gballoc_hl` implementation is governed by `GBALLOC_HL_TYPE` (of type string) which can be either:
 
       i. "PASSTHROUGH" - `gballoc_hl` shall route all its APIs directly to `gballoc_ll`.
 
@@ -36,4 +38,6 @@ As far as Windows is concerned there are several CMake options.
 
 Linux is not a concern at this moment.
 
-Both `gballoc_ll` and `gballoc_hl` shall have init/deinit functions.
+Both `gballoc_ll` and `gballoc_hl` shall have init/deinit functions. In many implementations, these are no-op.
+The init function can also be performed lazily for any module (`gballoc_hl` or `gballoc_ll`) that needs to do some initialization.
+In case of `gballoc_hl`, it will not lazily initialize the `gballoc_ll` unless it has its own initialization.

--- a/win32/devdoc/gballoc_hl_passthrough.md
+++ b/win32/devdoc/gballoc_hl_passthrough.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-gballoc_hl_passthrough is a module that delegates all call of its APIs to the ones from gballoc_ll. 
+gballoc_hl_passthrough is a module that delegates all call of its APIs to the ones from gballoc_ll.
 
 ## References
 
@@ -67,26 +67,7 @@ MOCKABLE_FUNCTION(, int, gballoc_hl_init, void*, gballoc_hl_init_params, void*, 
 
 `gballoc_hl_init` calls `gballoc_ll_init(gballoc_ll_init_params)`. Since `gballoc_hl` is passthrough it has no other functionality and `gballoc_hl_init_params` is ignored. This function is not thread-safe.
 
-**SRS_GBALLOC_HL_PASSTHROUGH_02_017: [** `gballoc_hl_init` shall call `lazy_init` with `do_init` as function to execute and `gballoc_ll_init_params` as parameter. **]**
-
-**SRS_GBALLOC_HL_PASSTHROUGH_02_002: [** `gballoc_hl_init` shall succeed and return 0. **]**
-
-**SRS_GBALLOC_HL_PASSTHROUGH_02_003: [** If  there are any failures then `gballoc_hl_init` shall fail and return a non-zero value. **]**
-
-
-### do_init(void* params)
-```c
-static int do_init(void* params)
-```
-
-`do_init` is a one-time-call function that initializes the module. 
-
-**SRS_GBALLOC_HL_PASSTHROUGH_02_018: [** `do_init` shall call `gballoc_ll_init(params)`. **]**
-
-**SRS_GBALLOC_HL_PASSTHROUGH_02_019: [** `do_init` shall return 0. **]**
-
-**SRS_GBALLOC_HL_PASSTHROUGH_02_020: [** If there are any failures then `do_init` shall fail and return a non-zero value. **]**
-
+**SRS_GBALLOC_HL_PASSTHROUGH_42_001: [** `gballoc_hl_init` shall call `gballoc_ll_init` as function to execute and `gballoc_ll_init_params` as parameter and return the result. **]**
 
 ### gballoc_hl_deinit
 ```c
@@ -95,11 +76,7 @@ MOCKABLE_FUNCTION(, void, gballoc_hl_deinit);
 
 `gballoc_hl_deinit` calls `gballoc_ll_deinit`. Since `gballoc_hl` is passthrough it has no other functionality.
 
-
 **SRS_GBALLOC_HL_PASSTHROUGH_02_004: [** `gballoc_hl_deinit` shall call `gballoc_ll_deinit`. **]**
-
-**SRS_GBALLOC_HL_PASSTHROUGH_02_021: [** `gballoc_hl_deinit` shall switch module's state to `LAZY_INIT_NOT_DONE` **]**
-
 
 ### gballoc_hl_malloc
 ```c
@@ -107,10 +84,6 @@ MOCKABLE_FUNCTION(, void*, gballoc_hl_malloc, size_t, size);
 ```
 
 `gballoc_hl_malloc` calls `gballoc_ll_malloc` and returns what `gballoc_ll_malloc` returned.
-
-**SRS_GBALLOC_HL_PASSTHROUGH_02_022: [** `gballoc_hl_malloc` shall call `lazy_init` passing as execution function `do_init` and `NULL` for argument. **]**
-
-**SRS_GBALLOC_HL_PASSTHROUGH_02_023: [** If `lazy_init` fail then `gballoc_hl_malloc` shall fail and return `NULL`. **]**
 
 **SRS_GBALLOC_HL_PASSTHROUGH_02_005: [** `gballoc_hl_malloc` shall call `gballoc_ll_malloc(size)` and return what `gballoc_ll_malloc` returned. **]**
 
@@ -122,10 +95,6 @@ MOCKABLE_FUNCTION(, void*, gballoc_hl_malloc_2, size_t, nmemb, size_t, size);
 
 `gballoc_hl_malloc_2` calls `gballoc_ll_malloc_2` and returns what `gballoc_ll_malloc_2` returned.
 
-**SRS_GBALLOC_HL_PASSTHROUGH_02_028: [** `gballoc_hl_malloc_2` shall call `lazy_init` passing as execution function `do_init` and `NULL` for argument. **]**
-
-**SRS_GBALLOC_HL_PASSTHROUGH_02_029: [** If `lazy_init` fail then `gballoc_hl_malloc_2` shall fail and return `NULL`. **]**
-
 **SRS_GBALLOC_HL_PASSTHROUGH_02_030: [** `gballoc_hl_malloc_2` shall call `gballoc_ll_malloc_2(size)` and return what `gballoc_ll_malloc_2` returned. **]**
 
 
@@ -135,10 +104,6 @@ MOCKABLE_FUNCTION(, void*, gballoc_hl_malloc_flex, size_t, base, size_t, nmemb, 
 ```
 
 `gballoc_hl_malloc_flex` calls `gballoc_ll_malloc_flex` and returns what `gballoc_ll_malloc_flex` returned.
-
-**SRS_GBALLOC_HL_PASSTHROUGH_02_031: [** `gballoc_hl_malloc_flex` shall call `lazy_init` passing as execution function `do_init` and `NULL` for argument. **]**
-
-**SRS_GBALLOC_HL_PASSTHROUGH_02_032: [** If `lazy_init` fail then `gballoc_hl_malloc_flex` shall fail and return `NULL`. **]**
 
 **SRS_GBALLOC_HL_PASSTHROUGH_02_033: [** `gballoc_hl_malloc_flex` shall call `gballoc_ll_malloc_flex(size)` and return what `gballoc_hl_malloc_flex` returned. **]**
 
@@ -159,8 +124,6 @@ MOCKABLE_FUNCTION(, size_t, gballoc_hl_size, void*, ptr);
 
 `gballoc_hl_size` gets the size of the allocated block at `ptr`.
 
-**SRS_GBALLOC_HL_PASSTHROUGH_01_002: [**  If the module was not initialized, `gballoc_hl_size` shall return 0. **]**
-
 **SRS_GBALLOC_HL_PASSTHROUGH_01_003: [** Otherwise, `gballoc_hl_size` shall call `gballoc_ll_size` with `ptr` as argument and return the result of `gballoc_ll_size`. **]**
 
 ### gballoc_hl_calloc
@@ -169,10 +132,6 @@ MOCKABLE_FUNCTION(, void*, gballoc_hl_calloc, size_t, nmemb, size_t, size);
 ```
 
 `gballoc_hl_calloc` calls `gballoc_ll_calloc`.
-
-**SRS_GBALLOC_HL_PASSTHROUGH_02_024: [** `gballoc_hl_calloc` shall call `lazy_init` passing as execution function `do_init` and `NULL` for argument. **]**
-
-**SRS_GBALLOC_HL_PASSTHROUGH_02_025: [** If `lazy_init` fail then `gballoc_hl_calloc` shall fail and return `NULL`.  **]**
 
 **SRS_GBALLOC_HL_PASSTHROUGH_02_007: [** `gballoc_hl_calloc` shall call `gballoc_ll_calloc(nmemb, size)` and return what `gballoc_ll_calloc` returned. **]**
 
@@ -184,10 +143,6 @@ MOCKABLE_FUNCTION(, void*, gballoc_hl_realloc, void*, ptr, size_t, size);
 
 `gballoc_hl_realloc` calls `gballoc_ll_realloc`.
 
-**SRS_GBALLOC_HL_PASSTHROUGH_02_026: [** `gballoc_hl_realloc` shall call `lazy_init` passing as execution function `do_init` and `NULL` for argument. **]**
-
-**SRS_GBALLOC_HL_PASSTHROUGH_02_027: [** If `lazy_init` fail then `gballoc_hl_realloc` shall fail and return `NULL`. **]**
-
 **SRS_GBALLOC_HL_PASSTHROUGH_02_008: [** `gballoc_hl_realloc` shall call `gballoc_ll_realloc(ptr, size)` and return what `gballoc_ll_realloc` returned. **]**
 
 
@@ -198,10 +153,6 @@ MOCKABLE_FUNCTION(, void*, gballoc_hl_realloc_2, void*, ptr, size_t, nmemb, size
 
 `gballoc_hl_realloc_2` calls `gballoc_ll_realloc_2` and returns what `gballoc_ll_realloc_2` returned.
 
-**SRS_GBALLOC_HL_PASSTHROUGH_02_034: [** `gballoc_hl_realloc_2` shall call `lazy_init` passing as execution function `do_init` and `NULL` for argument. **]**
-
-**SRS_GBALLOC_HL_PASSTHROUGH_02_035: [** If `lazy_init` fail then `gballoc_hl_realloc_2` shall fail and return `NULL`. **]**
-
 **SRS_GBALLOC_HL_PASSTHROUGH_02_036: [** `gballoc_hl_realloc_2` shall call `gballoc_ll_realloc_2(ptr, nmemb, size)` and return what `gballoc_ll_realloc_2` returned. **]**
 
 
@@ -211,10 +162,6 @@ MOCKABLE_FUNCTION(, void*, gballoc_hl_realloc_flex, void*, ptr, size_t, base, si
 ```
 
 `gballoc_hl_realloc_flex` calls `gballoc_ll_realloc_flex` and returns what `gballoc_ll_realloc_flex` returned.
-
-**SRS_GBALLOC_HL_PASSTHROUGH_02_037: [** `gballoc_hl_realloc_flex` shall call `lazy_init` passing as execution function `do_init` and `NULL` for argument. **]**
-
-**SRS_GBALLOC_HL_PASSTHROUGH_02_038: [** If `lazy_init` fail then `gballoc_hl_realloc_flex` shall fail and return `NULL`. **]**
 
 **SRS_GBALLOC_HL_PASSTHROUGH_02_039: [** `gballoc_hl_realloc_flex` shall call `gballoc_ll_realloc_flex(ptr, base, nmemb, size)` and return what `gballoc_ll_realloc_flex` returned. **]**
 
@@ -242,7 +189,7 @@ Since this is a passthough layer without any counter implementation `gballoc_hl_
 ```c
 MOCKABLE_FUNCTION(, int, gballoc_hl_get_realloc_latency_buckets, GBALLOC_LATENCY_BUCKETS*, latency_buckets_out);
 ```
-   
+
 Since this is a passthough layer without any counter implementation `gballoc_hl_get_realloc_latency_buckets` returns.
 
 **SRS_GBALLOC_HL_PASSTHROUGH_02_011: [** `gballoc_hl_get_realloc_latency_buckets` shall set `latency_buckets_out`'s bytes all to 0 and return 0. **]**

--- a/win32/src/gballoc_hl_passthrough.c
+++ b/win32/src/gballoc_hl_passthrough.c
@@ -15,9 +15,7 @@ int gballoc_hl_init(void* gballoc_hl_init_params, void* gballoc_ll_init_params)
     (void)gballoc_hl_init_params; /*are ignored, this is "passthrough*/
 
     /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_42_001: [ gballoc_hl_init shall call gballoc_ll_init as function to execute and gballoc_ll_init_params as parameter and return the result. ]*/
-    int result = gballoc_ll_init(gballoc_ll_init_params);
-
-    return result;
+    return gballoc_ll_init(gballoc_ll_init_params);
 }
 
 void gballoc_hl_deinit(void)
@@ -198,9 +196,7 @@ void gballoc_hl_print_stats(void)
 size_t gballoc_hl_size(void* ptr)
 {
     /* Codes_SRS_GBALLOC_HL_PASSTHROUGH_01_003: [ Otherwise, gballoc_hl_size shall call gballoc_ll_size with ptr as argument and return the result of gballoc_ll_size. ]*/
-    size_t result = gballoc_ll_size(ptr);
-
-    return result;
+    return gballoc_ll_size(ptr);
 }
 
 int gballoc_hl_set_option(const char* option_name, void* option_value)

--- a/win32/src/gballoc_hl_passthrough.c
+++ b/win32/src/gballoc_hl_passthrough.c
@@ -6,52 +6,16 @@
 #include "macro_utils/macro_utils.h"
 #include "c_logging/logger.h"
 
-#include "c_pal/lazy_init.h"
 #include "c_pal/gballoc_ll.h"
 
 #include "c_pal/gballoc_hl.h"
-
-static call_once_t g_lazy;
-
-static int do_init(void* params)
-{
-    int result;
-
-    void* gballoc_ll_init_params = params;
-
-    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_018: [ do_init shall call gballoc_ll_init(params). ]*/
-    if (gballoc_ll_init(gballoc_ll_init_params) != 0)
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_020: [ If there are any failures then do_init shall fail and return a non-zero value. ]*/
-        LogError("failure in gballoc_ll_init(gballoc_ll_init_params=%p)", gballoc_ll_init_params);
-        result = MU_FAILURE;
-    }
-    else
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_019: [ do_init shall return 0. ]*/
-        result = 0;
-    }
-    return result;
-}
 
 int gballoc_hl_init(void* gballoc_hl_init_params, void* gballoc_ll_init_params)
 {
     (void)gballoc_hl_init_params; /*are ignored, this is "passthrough*/
 
-    int result;
-    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_017: [ gballoc_hl_init shall call lazy_init with do_init as function to execute and gballoc_ll_init_params as parameter. ]*/
-    if (lazy_init(&g_lazy, do_init, gballoc_ll_init_params) != LAZY_INIT_OK)
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_003: [ If there are any failures then gballoc_hl_init shall fail and return a non-zero value. ]*/
-        LogError("failure in lazy_init(&g_lazy=%p, do_init=%p, gballoc_ll_init_params=%p)",
-            &g_lazy, do_init, gballoc_ll_init_params);
-        result = MU_FAILURE;
-    }
-    else
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_002: [ gballoc_hl_init shall succeed and return 0. ]*/
-        result = 0;
-    }
+    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_42_001: [ gballoc_hl_init shall call gballoc_ll_init as function to execute and gballoc_ll_init_params as parameter and return the result. ]*/
+    int result = gballoc_ll_init(gballoc_ll_init_params);
 
     return result;
 }
@@ -60,79 +24,40 @@ void gballoc_hl_deinit(void)
 {
     /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_004: [ gballoc_hl_deinit shall call gballoc_ll_deinit. ]*/
     gballoc_ll_deinit();
-
-    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_021: [ gballoc_hl_deinit shall switch module's state to LAZY_INIT_NOT_DONE ]*/
-    interlocked_exchange(&g_lazy, LAZY_INIT_NOT_DONE);
 }
 
 void* gballoc_hl_malloc(size_t size)
 {
-    void* result;
-    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_022: [ gballoc_hl_malloc shall call lazy_init passing as execution function do_init and NULL for argument. ]*/
-    if (lazy_init(&g_lazy, do_init, NULL) != LAZY_INIT_OK)
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_023: [ If lazy_init fail then gballoc_hl_malloc shall fail and return NULL. ]*/
-        LogError("failure in lazy_init(&g_lazy=%p, do_init=%p, gballoc_ll_init_params=%p)",
-            &g_lazy, do_init, NULL);
-        result = NULL;
-    }
-    else
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_005: [ gballoc_hl_malloc shall call gballoc_ll_malloc(size) and return what gballoc_ll_malloc returned. ]*/
-        result = gballoc_ll_malloc(size);
+    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_005: [ gballoc_hl_malloc shall call gballoc_ll_malloc(size) and return what gballoc_ll_malloc returned. ]*/
+    void* result = gballoc_ll_malloc(size);
 
-        if (result == NULL)
-        {
-            LogError("failure in gballoc_ll_malloc(size=%zu)", size);
-        }
+    if (result == NULL)
+    {
+        LogError("failure in gballoc_ll_malloc(size=%zu)", size);
     }
     return result;
 }
 
 void* gballoc_hl_malloc_2(size_t nmemb, size_t size)
 {
-    void* result;
-    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_028: [ gballoc_hl_malloc_2 shall call lazy_init passing as execution function do_init and NULL for argument. ]*/
-    if (lazy_init(&g_lazy, do_init, NULL) != LAZY_INIT_OK)
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_029: [ If lazy_init fail then gballoc_hl_malloc_2 shall fail and return NULL. ]*/
-        LogError("failure in lazy_init(&g_lazy=%p, do_init=%p, gballoc_ll_init_params=%p)",
-            &g_lazy, do_init, NULL);
-        result = NULL;
-    }
-    else
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_030: [ gballoc_hl_malloc_2 shall call gballoc_ll_malloc_2(size) and return what gballoc_ll_malloc_2 returned. ]*/
-        result = gballoc_ll_malloc_2(nmemb, size);
+    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_030: [ gballoc_hl_malloc_2 shall call gballoc_ll_malloc_2(size) and return what gballoc_ll_malloc_2 returned. ]*/
+    void* result = gballoc_ll_malloc_2(nmemb, size);
 
-        if (result == NULL)
-        {
-            LogError("failure in gballoc_ll_malloc_2(nmemb=%zu, size=%zu);", nmemb, size);
-        }
+    if (result == NULL)
+    {
+        LogError("failure in gballoc_ll_malloc_2(nmemb=%zu, size=%zu);", nmemb, size);
     }
     return result;
 }
 
 void* gballoc_hl_malloc_flex(size_t base, size_t nmemb, size_t size)
 {
-    void* result;
-    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_031: [ gballoc_hl_malloc_flex shall call lazy_init passing as execution function do_init and NULL for argument. ]*/
-    if (lazy_init(&g_lazy, do_init, NULL) != LAZY_INIT_OK)
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_032: [ If lazy_init fail then gballoc_hl_malloc_flex shall fail and return NULL. ]*/
-        LogError("failure in lazy_init(&g_lazy=%p, do_init=%p, gballoc_ll_init_params=%p)",
-            &g_lazy, do_init, NULL);
-        result = NULL;
-    }
-    else
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_033: [ gballoc_hl_malloc_flex shall call gballoc_ll_malloc_flex(size) and return what gballoc_hl_malloc_flex returned. ]*/
-        result = gballoc_ll_malloc_flex(base, nmemb, size);
+    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_033: [ gballoc_hl_malloc_flex shall call gballoc_ll_malloc_flex(size) and return what gballoc_hl_malloc_flex returned. ]*/
+    void* result = gballoc_ll_malloc_flex(base, nmemb, size);
 
-        if (result == NULL)
-        {
-            LogError("failure in gballoc_ll_malloc_flex(base=%zu, nmemb=%zu, size=%zu);", base, nmemb, size);
-        }
+    if (result == NULL)
+    {
+        LogError("failure in gballoc_ll_malloc_flex(base=%zu, nmemb=%zu, size=%zu);", base, nmemb, size);
     }
     return result;
 }
@@ -145,24 +70,12 @@ void gballoc_hl_free(void* ptr)
 
 void* gballoc_hl_calloc(size_t nmemb, size_t size)
 {
-    void* result;
-    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_024: [ gballoc_hl_calloc shall call lazy_init passing as execution function do_init and NULL for argument. ]*/
-    if (lazy_init(&g_lazy, do_init, NULL) != LAZY_INIT_OK)
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_025: [ If lazy_init fail then gballoc_hl_calloc shall fail and return NULL. ]*/
-        LogError("failure in lazy_init(&g_lazy=%p, do_init=%p, gballoc_ll_init_params=%p)",
-            &g_lazy, do_init, NULL);
-        result = NULL;
-    }
-    else
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_007: [ gballoc_hl_calloc shall call gballoc_ll_calloc(nmemb, size) and return what gballoc_ll_calloc returned. ]*/
-        result = gballoc_ll_calloc(nmemb, size);
+    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_007: [ gballoc_hl_calloc shall call gballoc_ll_calloc(nmemb, size) and return what gballoc_ll_calloc returned. ]*/
+    void* result = gballoc_ll_calloc(nmemb, size);
 
-        if (result == NULL)
-        {
-            LogError("failure in gballoc_ll_calloc(nmemb=%zu, size=%zu)", nmemb, size);
-        }
+    if (result == NULL)
+    {
+        LogError("failure in gballoc_ll_calloc(nmemb=%zu, size=%zu)", nmemb, size);
     }
     return result;
 }
@@ -170,76 +83,37 @@ void* gballoc_hl_calloc(size_t nmemb, size_t size)
 
 void* gballoc_hl_realloc(void* ptr, size_t size)
 {
-    void* result;
-    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_026: [ gballoc_hl_realloc shall call lazy_init passing as execution function do_init and NULL for argument. ]*/
-    if (lazy_init(&g_lazy, do_init, NULL) != LAZY_INIT_OK)
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_027: [ If lazy_init fail then gballoc_hl_realloc shall fail and return NULL. ]*/
-        LogError("failure in lazy_init(&g_lazy=%p, do_init=%p, gballoc_ll_init_params=%p)",
-            &g_lazy, do_init, NULL);
-        result = NULL;
-    }
-    else
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_008: [ gballoc_hl_realloc shall call gballoc_ll_realloc(ptr, size) and return what gballoc_ll_realloc returned. ]*/
-        result = gballoc_ll_realloc(ptr, size);
+    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_008: [ gballoc_hl_realloc shall call gballoc_ll_realloc(ptr, size) and return what gballoc_ll_realloc returned. ]*/
+    void* result = gballoc_ll_realloc(ptr, size);
 
-        if (result == NULL)
-        {
-            LogError("Failure in gballoc_ll_realloc(ptr=%p, size=%zu)", ptr, size);
-        }
+    if (result == NULL)
+    {
+        LogError("Failure in gballoc_ll_realloc(ptr=%p, size=%zu)", ptr, size);
     }
-
     return result;
 }
 
 void* gballoc_hl_realloc_2(void* ptr, size_t nmemb, size_t size)
 {
-    void* result;
-    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_034: [ gballoc_hl_realloc_2 shall call lazy_init passing as execution function do_init and NULL for argument. ]*/
-    if (lazy_init(&g_lazy, do_init, NULL) != LAZY_INIT_OK)
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_035: [ If lazy_init fail then gballoc_hl_realloc_2 shall fail and return NULL. ]*/
-        LogError("failure in lazy_init(&g_lazy=%p, do_init=%p, gballoc_ll_init_params=%p)",
-            &g_lazy, do_init, NULL);
-        result = NULL;
-    }
-    else
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_036: [ gballoc_hl_realloc_2 shall call gballoc_ll_realloc_2(ptr, nmemb, size) and return what gballoc_ll_realloc_2 returned. ]*/
-        result = gballoc_ll_realloc_2(ptr, nmemb, size);
+    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_036: [ gballoc_hl_realloc_2 shall call gballoc_ll_realloc_2(ptr, nmemb, size) and return what gballoc_ll_realloc_2 returned. ]*/
+    void* result = gballoc_ll_realloc_2(ptr, nmemb, size);
 
-        if (result == NULL)
-        {
-            LogError("Failure in gballoc_ll_realloc_2(ptr=%p, nmemb=%zu, size=%zu)", ptr, nmemb, size);
-        }
+    if (result == NULL)
+    {
+        LogError("Failure in gballoc_ll_realloc_2(ptr=%p, nmemb=%zu, size=%zu)", ptr, nmemb, size);
     }
-
     return result;
 }
 
 void* gballoc_hl_realloc_flex(void* ptr, size_t base, size_t nmemb, size_t size)
 {
-    void* result;
-    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_037: [ gballoc_hl_realloc_flex shall call lazy_init passing as execution function do_init and NULL for argument. ]*/
-    if (lazy_init(&g_lazy, do_init, NULL) != LAZY_INIT_OK)
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_038: [ If lazy_init fail then gballoc_hl_realloc_flex shall fail and return NULL. ]*/
-        LogError("failure in lazy_init(&g_lazy=%p, do_init=%p, gballoc_ll_init_params=%p)",
-            &g_lazy, do_init, NULL);
-        result = NULL;
-    }
-    else
-    {
-        /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_039: [ gballoc_hl_realloc_flex shall call gballoc_ll_realloc_flex(ptr, base, nmemb, size) and return what gballoc_ll_realloc_flex returned. ]*/
-        result = gballoc_ll_realloc_flex(ptr, base, nmemb, size);
+    /*Codes_SRS_GBALLOC_HL_PASSTHROUGH_02_039: [ gballoc_hl_realloc_flex shall call gballoc_ll_realloc_flex(ptr, base, nmemb, size) and return what gballoc_ll_realloc_flex returned. ]*/
+    void* result = gballoc_ll_realloc_flex(ptr, base, nmemb, size);
 
-        if (result == NULL)
-        {
-            LogError("Failure in gballoc_ll_realloc_flex(ptr=%p, base=%zu, nmemb=%zu, size=%zu)", ptr, base, nmemb, size);
-        }
+    if (result == NULL)
+    {
+        LogError("Failure in gballoc_ll_realloc_flex(ptr=%p, base=%zu, nmemb=%zu, size=%zu)", ptr, base, nmemb, size);
     }
-
     return result;
 }
 
@@ -323,19 +197,8 @@ void gballoc_hl_print_stats(void)
 
 size_t gballoc_hl_size(void* ptr)
 {
-    size_t result;
-
-    if (interlocked_add(&g_lazy, 0) == LAZY_INIT_NOT_DONE)
-    {
-        /* Codes_SRS_GBALLOC_HL_PASSTHROUGH_01_002: [ If the module was not initialized, gballoc_hl_size shall return 0. ]*/
-        LogError("Not initialized");
-        result = 0;
-    }
-    else
-    {
-        /* Codes_SRS_GBALLOC_HL_PASSTHROUGH_01_003: [ Otherwise, gballoc_hl_size shall call gballoc_ll_size with ptr as argument and return the result of gballoc_ll_size. ]*/
-        result = gballoc_ll_size(ptr);
-    }
+    /* Codes_SRS_GBALLOC_HL_PASSTHROUGH_01_003: [ Otherwise, gballoc_hl_size shall call gballoc_ll_size with ptr as argument and return the result of gballoc_ll_size. ]*/
+    size_t result = gballoc_ll_size(ptr);
 
     return result;
 }


### PR DESCRIPTION
It was observed in some CPU profiling that every call to malloc does an `interlocked_compare_exchange`.
This is because gballoc has a lazy initialization.

Most of the gballoc implementations do **not** have an init/deinit implementation and they just no-op. However, `gballoc_hl_passthrough` was doing a lazy init _just in case_ it needed to lazy initialize the `gballoc_ll`. This is not necessary as the only `gballoc_ll` which does initialization (`gballoc_ll_win32heap`) also does `lazy_init` on its calls. Therefore, we can leave it to the LL to `lazy_init` when needed and avoid doing so for most of the LL that don't do any initialization (passthrough, jemalloc, mimalloc).

This is a small perf improvement, but low-hanging fruit and can add up when there are many allocations happening.